### PR TITLE
feat(hip3): dex awareness across adapter, market_data, and examples

### DIFF
--- a/bots/btc_conservative.yaml
+++ b/bots/btc_conservative.yaml
@@ -10,6 +10,13 @@ active: true  # Options: true/false - Enable/disable this trading strategy
 exchange:
   type: "hyperliquid"  # Exchange type (options: "hyperliquid", "hl")
   testnet: true        # Options: true/false - Use testnet for development
+  # dex: "felix"       # Optional HIP-3 builder-deployed perp dex (e.g. "felix",
+                       # "unit"). Default null = main perp dex. HIP-3 symbols
+                       # are namespaced "felix:CRCL"; use the prefix here.
+  # account_address: "0x..."  # Optional master address when the private key
+                              # is an agent / API wallet. Falls back to
+                              # TESTNET_WALLET_ADDRESS / MAINNET_WALLET_ADDRESS
+                              # env vars, or the signer's own address.
 
 account:
   max_allocation_pct: 10.0  # Uses only 10% of total account (range: 1-100%)

--- a/learning_examples/02_market_data/get_all_prices.py
+++ b/learning_examples/02_market_data/get_all_prices.py
@@ -16,7 +16,11 @@ load_dotenv()
 # You can only use this endpoint on the official Hyperliquid public API.
 # It is not available through Chainstack, as the open-source node implementation does not support it yet.
 BASE_URL = os.getenv("HYPERLIQUID_TESTNET_PUBLIC_BASE_URL")
-ASSETS_TO_SHOW = ["BTC", "ETH", "SOL", "DOGE", "AVAX"]
+# HIP-3: optional builder-deployed dex name (e.g. "felix"). Empty = main perp.
+DEX = os.getenv("DEX", "")
+ASSETS_TO_SHOW = (
+    ["BTC", "ETH", "SOL", "DOGE", "AVAX"] if not DEX else None  # show all on HIP-3
+)
 
 
 async def method_1_sdk() -> Optional[Dict[str, str]]:
@@ -26,13 +30,14 @@ async def method_1_sdk() -> Optional[Dict[str, str]]:
 
     try:
         info = Info(BASE_URL, skip_ws=True)
-        all_prices = info.all_mids()
+        all_prices = info.all_mids(dex=DEX)
 
-        print(f"Got prices for {len(all_prices)} assets")
-        for asset in ASSETS_TO_SHOW:
+        print(f"Got prices for {len(all_prices)} assets (dex={DEX or 'main'})")
+        assets = ASSETS_TO_SHOW or list(all_prices.keys())[:5]
+        for asset in assets:
             if asset in all_prices:
                 price = float(all_prices[asset])
-                print(f"   {asset}: ${price:,.2f}")
+                print(f"   {asset}: ${price:,.4f}")
 
         return all_prices
 
@@ -48,20 +53,23 @@ async def method_2_raw_api() -> Optional[Dict[str, str]]:
 
     try:
         async with httpx.AsyncClient() as client:
+            payload = {"type": "allMids"}
+            if DEX:
+                payload["dex"] = DEX
             response = await client.post(
                 f"{BASE_URL}/info",
-                json={"type": "allMids"},
+                json=payload,
                 headers={"Content-Type": "application/json"},
             )
 
             if response.status_code == 200:
                 all_prices = response.json()
-                print(f"Got prices for {len(all_prices)} assets")
-
-                for asset in ASSETS_TO_SHOW:
+                print(f"Got prices for {len(all_prices)} assets (dex={DEX or 'main'})")
+                assets = ASSETS_TO_SHOW or list(all_prices.keys())[:5]
+                for asset in assets:
                     if asset in all_prices:
                         price = float(all_prices[asset])
-                        print(f"   {asset}: ${price:,.2f}")
+                        print(f"   {asset}: ${price:,.4f}")
 
                 return all_prices
             else:

--- a/learning_examples/03_account_info/get_open_orders.py
+++ b/learning_examples/03_account_info/get_open_orders.py
@@ -15,6 +15,8 @@ load_dotenv()
 # It is not available through Chainstack, as the open-source node implementation does not support it yet.
 BASE_URL = os.getenv("HYPERLIQUID_TESTNET_PUBLIC_BASE_URL")
 WALLET_ADDRESS = os.getenv("TESTNET_WALLET_ADDRESS")
+# HIP-3: optional builder-deployed dex name. Empty = main perp.
+DEX = os.getenv("DEX", "")
 
 
 async def method_1_sdk():
@@ -24,9 +26,9 @@ async def method_1_sdk():
 
     try:
         info = Info(BASE_URL, skip_ws=True)
-        open_orders = info.open_orders(WALLET_ADDRESS)
+        open_orders = info.open_orders(WALLET_ADDRESS, dex=DEX)
 
-        print(f"Found {len(open_orders)} open orders")
+        print(f"Found {len(open_orders)} open orders (dex={DEX or 'main'})")
 
         if open_orders:
             for order in open_orders:
@@ -65,9 +67,12 @@ async def method_2_raw_api():
 
     try:
         async with httpx.AsyncClient() as client:
+            payload = {"type": "openOrders", "user": WALLET_ADDRESS}
+            if DEX:
+                payload["dex"] = DEX
             response = await client.post(
                 f"{BASE_URL}/info",
-                json={"type": "openOrders", "user": WALLET_ADDRESS},
+                json=payload,
                 headers={"Content-Type": "application/json"},
             )
 

--- a/learning_examples/03_account_info/get_user_state.py
+++ b/learning_examples/03_account_info/get_user_state.py
@@ -13,8 +13,12 @@ from hyperliquid.info import Info
 
 load_dotenv()
 
-BASE_URL = os.getenv("HYPERLIQUID_CHAINSTACK_BASE_URL")
+BASE_URL = os.getenv("HYPERLIQUID_CHAINSTACK_BASE_URL") or os.getenv(
+    "HYPERLIQUID_TESTNET_PUBLIC_BASE_URL"
+)
 WALLET_ADDRESS = os.getenv("TESTNET_WALLET_ADDRESS")
+# HIP-3: optional builder-deployed dex name. Empty = main perp.
+DEX = os.getenv("DEX", "")
 
 
 async def method_1_sdk() -> Optional[Account]:
@@ -26,8 +30,8 @@ async def method_1_sdk() -> Optional[Account]:
         print("Connecting to Hyperliquid testnet...")
         info = Info(BASE_URL, skip_ws=True)
 
-        user_state = info.user_state(WALLET_ADDRESS)
-        print("Connection successful! API responded with account data")
+        user_state = info.user_state(WALLET_ADDRESS, dex=DEX)
+        print(f"Connection successful! API responded with account data (dex={DEX or 'main'})")
 
         margin_summary = user_state.get("marginSummary", {})
         account_value = float(margin_summary.get("accountValue", 0))
@@ -53,9 +57,12 @@ async def method_2_raw_api() -> Optional[Account]:
     try:
         print("Making direct HTTP request to Hyperliquid API...")
         async with httpx.AsyncClient() as client:
+            payload = {"type": "clearinghouseState", "user": WALLET_ADDRESS}
+            if DEX:
+                payload["dex"] = DEX
             response = await client.post(
                 f"{BASE_URL}/info",
-                json={"type": "clearinghouseState", "user": WALLET_ADDRESS},
+                json=payload,
                 headers={"Content-Type": "application/json"},
             )
 

--- a/learning_examples/05_funding/get_funding_rates.py
+++ b/learning_examples/05_funding/get_funding_rates.py
@@ -14,50 +14,64 @@ load_dotenv()
 
 BASE_URL = os.getenv("HYPERLIQUID_PUBLIC_BASE_URL")
 MIN_FUNDING_RATE = 0.0001  # 0.01% minimum threshold
+# HIP-3 dex sweep is comma-separated; "" means main perp.
+# Example: DEXES="" or DEXES=",felix,unit" or DEXES="all" to iterate every dex.
+DEXES_ENV = os.getenv("DEXES", "")
 
 
 async def get_funding_rates_sdk() -> Optional[List[Dict]]:
-    """Method 1: Using Hyperliquid Python SDK"""
-    print("Method 1: Hyperliquid SDK")
+    """Method 1: Using Hyperliquid Python SDK across all perp dexes (HIP-3)."""
+    print("Method 1: Hyperliquid SDK (multi-dex)")
     print("-" * 30)
 
     try:
         info = Info(BASE_URL, skip_ws=True)
-        meta_and_contexts = info.meta_and_asset_ctxs()
-        
-        funding_opportunities = []
-        
-        if meta_and_contexts and len(meta_and_contexts) >= 2:
-            meta = meta_and_contexts[0]
-            asset_ctxs = meta_and_contexts[1]
-            
-            # Map asset names from universe to contexts by index
-            for i, asset_ctx in enumerate(asset_ctxs):
-                asset_name = meta["universe"][i]["name"] if i < len(meta["universe"]) else f"UNKNOWN_{i}"
-                funding_rate = float(asset_ctx.get("funding", "0"))
-                mark_price = float(asset_ctx.get("markPx", "0"))
-                
-                if funding_rate > MIN_FUNDING_RATE:
-                    funding_opportunities.append({
-                        "asset": asset_name,
-                        "funding_rate": funding_rate,
-                        "funding_rate_pct": funding_rate * 100,
-                        "annual_rate_pct": funding_rate * 100 * 365 * 24,  # 24 payments/day
-                        "mark_price": mark_price
-                    })
-            
-            funding_opportunities.sort(key=lambda x: x["funding_rate"], reverse=True)
-            
-            print(f"Found {len(funding_opportunities)} positive funding opportunities")
-            print()
-            
-            for i, opp in enumerate(funding_opportunities[:10], 1):
-                print(f"{i:2d}. {opp['asset']:>6}: {opp['funding_rate_pct']:+7.4f}% "
-                      f"(Annual: {opp['annual_rate_pct']:+7.1f}%) @ ${opp['mark_price']:,.2f}")
-            
-            return funding_opportunities
-        
-        return None
+        # Build the list of dexes to query.
+        if DEXES_ENV == "all":
+            dexes = info.perp_dexs() or []
+            dex_names = [""] + [
+                d.get("name") for d in dexes if isinstance(d, dict) and d.get("name")
+            ]
+        elif DEXES_ENV:
+            dex_names = [d.strip() for d in DEXES_ENV.split(",")]
+        else:
+            dex_names = [""]
+
+        funding_opportunities: List[Dict] = []
+        for dex_name in dex_names:
+            try:
+                meta = info.meta(dex=dex_name)
+                # meta_and_asset_ctxs is main-only on the SDK; fall back per-dex
+                # to a raw POST when the helper is unavailable.
+                ctxs = info.post(
+                    "/info", {"type": "metaAndAssetCtxs", **({"dex": dex_name} if dex_name else {})}
+                )
+                if not (isinstance(ctxs, list) and len(ctxs) >= 2):
+                    continue
+                _, asset_ctxs = ctxs[0], ctxs[1]
+                universe = meta.get("universe", [])
+                for i, asset_ctx in enumerate(asset_ctxs):
+                    asset_name = universe[i]["name"] if i < len(universe) else f"UNKNOWN_{i}"
+                    funding_rate = float(asset_ctx.get("funding", "0"))
+                    mark_price = float(asset_ctx.get("markPx", "0"))
+                    if funding_rate > MIN_FUNDING_RATE:
+                        funding_opportunities.append({
+                            "asset": asset_name,
+                            "dex": dex_name or "main",
+                            "funding_rate": funding_rate,
+                            "funding_rate_pct": funding_rate * 100,
+                            "annual_rate_pct": funding_rate * 100 * 365 * 24,
+                            "mark_price": mark_price,
+                        })
+            except Exception as e:
+                print(f"  skip dex={dex_name!r}: {e}")
+
+        funding_opportunities.sort(key=lambda x: x["funding_rate"], reverse=True)
+        print(f"Found {len(funding_opportunities)} positive funding opportunities across {len(dex_names)} dex(es)")
+        for i, opp in enumerate(funding_opportunities[:10], 1):
+            print(f"{i:2d}. [{opp['dex']:>6}] {opp['asset']:>14}: {opp['funding_rate_pct']:+7.4f}% "
+                  f"(Annual: {opp['annual_rate_pct']:+7.1f}%) @ ${opp['mark_price']:,.4f}")
+        return funding_opportunities
 
     except Exception as e:
         print(f"SDK method failed: {e}")

--- a/learning_examples/05_funding/get_funding_rates.py
+++ b/learning_examples/05_funding/get_funding_rates.py
@@ -63,7 +63,7 @@ async def get_funding_rates_sdk() -> Optional[List[Dict]]:
                             "annual_rate_pct": funding_rate * 100 * 365 * 24,
                             "mark_price": mark_price,
                         })
-            except Exception as e:
+            except (httpx.HTTPError, ValueError, KeyError) as e:
                 print(f"  skip dex={dex_name!r}: {e}")
 
         funding_opportunities.sort(key=lambda x: x["funding_rate"], reverse=True)
@@ -79,56 +79,75 @@ async def get_funding_rates_sdk() -> Optional[List[Dict]]:
 
 
 async def get_funding_rates_raw() -> Optional[List[Dict]]:
-    """Method 2: Raw HTTP API call"""
-    print("\nMethod 2: Raw HTTP API")
+    """Method 2: Raw HTTP API across the requested dexes (HIP-3)."""
+    print("\nMethod 2: Raw HTTP API (multi-dex)")
     print("-" * 30)
 
+    if DEXES_ENV == "all":
+        # Need a discovery call first; reuse the SDK helper.
+        from hyperliquid.info import Info as _Info
+
+        info = _Info(BASE_URL, skip_ws=True)
+        dexes = info.perp_dexs() or []
+        dex_names = [""] + [
+            d.get("name") for d in dexes if isinstance(d, dict) and d.get("name")
+        ]
+    elif DEXES_ENV:
+        dex_names = [d.strip() for d in DEXES_ENV.split(",")]
+    else:
+        dex_names = [""]
+
+    funding_opportunities: List[Dict] = []
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.post(
-                f"{BASE_URL}/info",
-                json={"type": "metaAndAssetCtxs"},
-                headers={"Content-Type": "application/json"},
-            )
+            for dex_name in dex_names:
+                payload = {"type": "metaAndAssetCtxs"}
+                if dex_name:
+                    payload["dex"] = dex_name
+                try:
+                    response = await client.post(
+                        f"{BASE_URL}/info",
+                        json=payload,
+                        headers={"Content-Type": "application/json"},
+                    )
+                    if response.status_code != 200:
+                        print(f"  skip dex={dex_name!r}: HTTP {response.status_code}")
+                        continue
+                    data = response.json()
+                except (httpx.HTTPError, ValueError) as e:
+                    print(f"  skip dex={dex_name!r}: {e}")
+                    continue
 
-            if response.status_code == 200:
-                data = response.json()
-                funding_opportunities = []
-                
-                if len(data) >= 2:
-                    meta = data[0]
-                    asset_ctxs = data[1]
-                    
-                    # Map asset names from universe to contexts by index
-                    for i, asset_ctx in enumerate(asset_ctxs):
-                        asset_name = meta["universe"][i]["name"] if i < len(meta["universe"]) else f"UNKNOWN_{i}"
-                        funding_rate = float(asset_ctx.get("funding", "0"))
-                        mark_price = float(asset_ctx.get("markPx", "0"))
-                        
-                        if funding_rate > MIN_FUNDING_RATE:
-                            funding_opportunities.append({
-                                "asset": asset_name,
-                                "funding_rate": funding_rate,
-                                "funding_rate_pct": funding_rate * 100,
-                                "annual_rate_pct": funding_rate * 100 * 365 * 24,
-                                "mark_price": mark_price
-                            })
-                    
-                    funding_opportunities.sort(key=lambda x: x["funding_rate"], reverse=True)
-                    
-                    print(f"Found {len(funding_opportunities)} positive funding opportunities")
-                    print()
-                    
-                    for i, opp in enumerate(funding_opportunities[:10], 1):
-                        print(f"{i:2d}. {opp['asset']:>6}: {opp['funding_rate_pct']:+7.4f}% "
-                              f"(Annual: {opp['annual_rate_pct']:+7.1f}%) @ ${opp['mark_price']:,.2f}")
-                    
-                    return funding_opportunities
-            else:
-                print(f"HTTP failed: {response.status_code}")
-                return None
+                if not (isinstance(data, list) and len(data) >= 2):
+                    continue
+                meta, asset_ctxs = data[0], data[1]
+                universe = meta.get("universe", [])
+                for i, asset_ctx in enumerate(asset_ctxs):
+                    asset_name = (
+                        universe[i]["name"]
+                        if i < len(universe)
+                        else f"UNKNOWN_{i}"
+                    )
+                    funding_rate = float(asset_ctx.get("funding", "0"))
+                    mark_price = float(asset_ctx.get("markPx", "0"))
+                    if funding_rate > MIN_FUNDING_RATE:
+                        funding_opportunities.append({
+                            "asset": asset_name,
+                            "dex": dex_name or "main",
+                            "funding_rate": funding_rate,
+                            "funding_rate_pct": funding_rate * 100,
+                            "annual_rate_pct": funding_rate * 100 * 365 * 24,
+                            "mark_price": mark_price,
+                        })
 
-    except Exception as e:
+            funding_opportunities.sort(key=lambda x: x["funding_rate"], reverse=True)
+            print(f"Found {len(funding_opportunities)} positive funding opportunities across {len(dex_names)} dex(es)")
+            for i, opp in enumerate(funding_opportunities[:10], 1):
+                print(f"{i:2d}. [{opp['dex']:>6}] {opp['asset']:>14}: {opp['funding_rate_pct']:+7.4f}% "
+                      f"(Annual: {opp['annual_rate_pct']:+7.1f}%) @ ${opp['mark_price']:,.4f}")
+            return funding_opportunities
+
+    except (httpx.HTTPError, ValueError) as e:
         print(f"HTTP method failed: {e}")
         return None
 

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -158,8 +158,12 @@ class GridConfig:
             raise ValueError("symbol cannot be empty")
         if not 3 <= self.levels <= 50:
             raise ValueError("levels must be between 3 and 50")
-        if self.dex is not None and not self.dex.strip():
-            raise ValueError("dex must be None or a non-empty string")
+        if self.dex is not None:
+            if not isinstance(self.dex, str):
+                raise ValueError("dex must be a string or None")
+            self.dex = self.dex.strip()
+            if not self.dex:
+                raise ValueError("dex must be None or a non-empty string")
         self.price_range.validate()
         self.position_sizing.validate()
 
@@ -241,8 +245,12 @@ class ExchangeConfig:
         """Validate exchange configuration"""
         if not self.type:
             raise ValueError("exchange type cannot be empty")
-        if self.dex is not None and not self.dex.strip():
-            raise ValueError("dex must be None or a non-empty string")
+        if self.dex is not None:
+            if not isinstance(self.dex, str):
+                raise ValueError("dex must be a string or None")
+            self.dex = self.dex.strip()
+            if not self.dex:
+                raise ValueError("dex must be None or a non-empty string")
 
 
 @dataclass

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -142,7 +142,8 @@ class GridConfig:
     """Grid configuration.
 
     `dex` selects a HIP-3 builder-deployed perp dex (None = main perp dex).
-    `is_spot` switches the asset namespace to spot pairs.
+    HIP-3 perps use namespaced symbols like "felix:CRCL"; the dex prefix is
+    auto-inferred from the symbol when `dex` is unset.
     """
 
     symbol: str = "BTC"
@@ -150,7 +151,6 @@ class GridConfig:
     price_range: PriceRangeConfig = field(default_factory=PriceRangeConfig)
     position_sizing: PositionSizingConfig = field(default_factory=PositionSizingConfig)
     dex: Optional[str] = None
-    is_spot: bool = False
 
     def validate(self) -> None:
         """Validate grid configuration"""

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -139,12 +139,18 @@ class PositionSizingConfig:
 
 @dataclass
 class GridConfig:
-    """Grid configuration"""
+    """Grid configuration.
+
+    `dex` selects a HIP-3 builder-deployed perp dex (None = main perp dex).
+    `is_spot` switches the asset namespace to spot pairs.
+    """
 
     symbol: str = "BTC"
     levels: int = 15  # Number of grid levels
     price_range: PriceRangeConfig = field(default_factory=PriceRangeConfig)
     position_sizing: PositionSizingConfig = field(default_factory=PositionSizingConfig)
+    dex: Optional[str] = None
+    is_spot: bool = False
 
     def validate(self) -> None:
         """Validate grid configuration"""
@@ -152,6 +158,8 @@ class GridConfig:
             raise ValueError("symbol cannot be empty")
         if not 3 <= self.levels <= 50:
             raise ValueError("levels must be between 3 and 50")
+        if self.dex is not None and not self.dex.strip():
+            raise ValueError("dex must be None or a non-empty string")
         self.price_range.validate()
         self.position_sizing.validate()
 
@@ -217,15 +225,24 @@ class MarketDataConfig:
 
 @dataclass
 class ExchangeConfig:
-    """Exchange configuration settings"""
+    """Exchange configuration settings.
+
+    `dex` selects a HIP-3 builder-deployed perp dex at adapter level
+    (None = main perp dex). Bot strategies may further narrow per-symbol
+    via GridConfig.dex.
+    """
 
     type: str = "hyperliquid"  # Exchange type (hyperliquid, hl, etc.)
     testnet: bool = True  # Use testnet for development
+    dex: Optional[str] = None
+    account_address: Optional[str] = None
 
     def validate(self) -> None:
         """Validate exchange configuration"""
         if not self.type:
             raise ValueError("exchange type cannot be empty")
+        if self.dex is not None and not self.dex.strip():
+            raise ValueError("dex must be None or a non-empty string")
 
 
 @dataclass

--- a/src/exchanges/__init__.py
+++ b/src/exchanges/__init__.py
@@ -54,11 +54,14 @@ def create_exchange_adapter(exchange_type: str, config: dict):
         account_address = config.get("account_address") or os.getenv(
             "TESTNET_WALLET_ADDRESS" if testnet else "MAINNET_WALLET_ADDRESS"
         )
+        dex = config.get("dex")
 
         if not private_key:
             raise ValueError("private_key is required for Hyperliquid")
 
-        return exchange_class(private_key, testnet, account_address=account_address)
+        return exchange_class(
+            private_key, testnet, account_address=account_address, dex=dex
+        )
 
     # Future exchanges will have their own initialization logic here
     # elif exchange_type == "binance":

--- a/src/exchanges/hyperliquid/adapter.py
+++ b/src/exchanges/hyperliquid/adapter.py
@@ -594,6 +594,8 @@ class HyperliquidAdapter(ExchangeAdapter):
             positions: List[Position] = []
             for d in dex_list:
                 user_state = self.info.user_state(self.account_address, dex=d)
+                # Fetch mids once per dex and reuse for current_value calc.
+                mids = self.info.all_mids(dex=d) if user_state.get("assetPositions") else {}
                 for pos_info in user_state.get("assetPositions", []):
                     pos = pos_info.get("position", {})
                     position_size = float(pos.get("szi", 0))
@@ -602,7 +604,7 @@ class HyperliquidAdapter(ExchangeAdapter):
 
                     coin = pos.get("coin", "")
                     entry_price = float(pos.get("entryPx") or 0)
-                    current_price = await self.get_market_price(coin, dex=d)
+                    current_price = float(mids.get(coin, 0))
                     current_value = abs(position_size) * current_price
                     unrealized_pnl = float(pos.get("unrealizedPnl", 0))
 

--- a/src/exchanges/hyperliquid/adapter.py
+++ b/src/exchanges/hyperliquid/adapter.py
@@ -37,6 +37,7 @@ class HyperliquidAdapter(ExchangeAdapter):
         private_key: str,
         testnet: bool = True,
         account_address: Optional[str] = None,
+        dex: Optional[str] = None,
     ):
         super().__init__("Hyperliquid")
         self.private_key = private_key
@@ -48,6 +49,10 @@ class HyperliquidAdapter(ExchangeAdapter):
         # signer's own address (i.e. signer == master).
         self.account_address = account_address
 
+        # HIP-3 builder-deployed perp dex name; None = main perp dex (default).
+        # Per-call dex overrides are also accepted on get_balance/positions etc.
+        self.dex = dex
+
         # Hyperliquid SDK components (will be initialized on connect)
         self.info = None
         self.exchange = None
@@ -55,9 +60,11 @@ class HyperliquidAdapter(ExchangeAdapter):
         # Endpoint router for smart routing
         self.endpoint_router = get_endpoint_router(testnet)
 
-        # Asset metadata caches populated on connect
-        self._perp_sz_decimals: Dict[str, int] = {}
+        # Asset metadata caches populated on connect.
+        # Perp cache is keyed by (dex_name_or_empty, asset).
+        self._perp_sz_decimals: Dict[tuple, int] = {}
         self._spot_sz_decimals: Dict[str, int] = {}
+        self._known_dexes: List[str] = [""]  # "" = main
 
     async def connect(self) -> bool:
         """Connect to Hyperliquid with smart endpoint routing"""
@@ -119,14 +126,25 @@ class HyperliquidAdapter(ExchangeAdapter):
             return False
 
     def _load_asset_metadata(self) -> None:
+        # Discover available HIP-3 dexes; main perp is "" by SDK convention.
         try:
-            meta = self.info.meta()
-            for asset_info in meta.get("universe", []):
-                name = asset_info.get("name")
-                if name is not None:
-                    self._perp_sz_decimals[name] = int(asset_info.get("szDecimals", 0))
+            dexes = self.info.perp_dexs() or []
+            self._known_dexes = [""] + [d.get("name") for d in dexes if isinstance(d, dict) and d.get("name")]
         except Exception as e:
-            print(f"⚠️ Failed to load perp metadata: {e}")
+            print(f"⚠️ Failed to discover perp dexes (HIP-3 support disabled): {e}")
+            self._known_dexes = [""]
+
+        for dex_name in self._known_dexes:
+            try:
+                meta = self.info.meta(dex=dex_name)
+                for asset_info in meta.get("universe", []):
+                    name = asset_info.get("name")
+                    if name is not None:
+                        self._perp_sz_decimals[(dex_name, name)] = int(
+                            asset_info.get("szDecimals", 0)
+                        )
+            except Exception as e:
+                print(f"⚠️ Failed to load perp metadata for dex={dex_name!r}: {e}")
 
         try:
             spot_meta = self.info.spot_meta()
@@ -172,21 +190,49 @@ class HyperliquidAdapter(ExchangeAdapter):
     def _is_spot(self, asset: str) -> bool:
         return "/" in asset or asset.startswith("@")
 
-    def _sz_decimals(self, asset: str) -> int:
-        cache = self._spot_sz_decimals if self._is_spot(asset) else self._perp_sz_decimals
-        if asset not in cache:
-            raise RuntimeError(
-                f"Missing precision metadata for {asset}; meta()/spot_meta() may have failed at connect"
-            )
-        return cache[asset]
+    def _dex_arg(self, dex: Optional[str]) -> str:
+        """Resolve to the SDK's dex string ('' = main perp).
 
-    def _round_price(self, asset: str, price: float) -> float:
+        If dex is unspecified, fall back to the adapter's configured dex.
+        """
+        return (dex if dex is not None else self.dex) or ""
+
+    def _infer_dex_from_asset(self, asset: str, dex: Optional[str] = None) -> str:
+        """HIP-3 asset names are namespaced as '<dex>:<symbol>'. If `dex` is
+        unspecified and the asset has a colon prefix, take the prefix; else
+        fall back to the adapter's default dex.
+        """
+        if dex is not None:
+            return dex
+        if ":" in asset and not asset.startswith("@"):
+            return asset.split(":", 1)[0]
+        return self._dex_arg(None)
+
+    def _sz_decimals(self, asset: str, dex: Optional[str] = None) -> int:
+        if self._is_spot(asset):
+            if asset not in self._spot_sz_decimals:
+                raise RuntimeError(
+                    f"Missing spot precision metadata for {asset}"
+                )
+            return self._spot_sz_decimals[asset]
+
+        resolved = self._infer_dex_from_asset(asset, dex)
+        key = (resolved, asset)
+        if key not in self._perp_sz_decimals:
+            raise RuntimeError(
+                f"Missing perp precision metadata for {asset} on dex={resolved!r}"
+            )
+        return self._perp_sz_decimals[key]
+
+    def _round_price(
+        self, asset: str, price: float, dex: Optional[str] = None
+    ) -> float:
         max_dec = (
             self.SPOT_PX_MAX_DECIMALS
             if self._is_spot(asset)
             else self.PERP_PX_MAX_DECIMALS
         )
-        px_decimals = max(0, max_dec - self._sz_decimals(asset))
+        px_decimals = max(0, max_dec - self._sz_decimals(asset, dex))
         # Hyperliquid: integer prices are exempt from the 5-sig-fig rule
         # (https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size)
         if price == int(price):
@@ -194,13 +240,20 @@ class HyperliquidAdapter(ExchangeAdapter):
         sig5 = float(f"{float(price):.5g}")
         return round(sig5, px_decimals)
 
-    def _round_size(self, asset: str, size: float) -> float:
-        rounded = round(float(size), self._sz_decimals(asset))
+    def _round_size(
+        self, asset: str, size: float, dex: Optional[str] = None
+    ) -> float:
+        sz_dec = self._sz_decimals(asset, dex)
+        rounded = round(float(size), sz_dec)
         if float(size) > 0 and rounded <= 0:
             raise RuntimeError(
-                f"Size {size} for {asset} rounds to 0 at szDecimals={self._sz_decimals(asset)}; below minimum increment"
+                f"Size {size} for {asset} rounds to 0 at szDecimals={sz_dec}; below minimum increment"
             )
         return rounded
+
+    def list_perp_dexes(self) -> List[str]:
+        """Return known perp dex names ('' = main perp dex)."""
+        return list(self._known_dexes)
 
     async def disconnect(self) -> None:
         """Disconnect from Hyperliquid"""
@@ -211,14 +264,15 @@ class HyperliquidAdapter(ExchangeAdapter):
 
     PERP_QUOTE_ALIASES = {"USD", "USDC", "USDC_PERP"}
 
-    async def get_balance(self, asset: str) -> Balance:
+    async def get_balance(
+        self, asset: str, dex: Optional[str] = None
+    ) -> Balance:
         """Get account balance for an asset.
 
         Asset names in PERP_QUOTE_ALIASES (USD / USDC / USDC_PERP) return the
-        cross-margin account value. Any other name reads from spot_user_state.
-        Note: "USDC" is treated as the perp quote here because the bot's grid
-        configs default to that — to read a spot USDC balance, look up the pair
-        directly via spot_meta.
+        cross-margin account value for the selected `dex` (defaults to the
+        adapter's configured dex; "" / None == main perp dex). Any other
+        name reads spot_user_state and ignores `dex`.
         """
         if not self.is_connected:
             raise RuntimeError("Not connected to exchange")
@@ -227,7 +281,7 @@ class HyperliquidAdapter(ExchangeAdapter):
             address = self.account_address
 
             if asset.upper() in self.PERP_QUOTE_ALIASES:
-                user_state = self.info.user_state(address)
+                user_state = self.info.user_state(address, dex=self._dex_arg(dex))
                 summary = user_state.get("crossMarginSummary", {})
                 account_value = float(summary.get("accountValue", 0))
                 margin_used = float(summary.get("totalMarginUsed", 0))
@@ -255,14 +309,20 @@ class HyperliquidAdapter(ExchangeAdapter):
         except Exception as e:
             raise RuntimeError(f"Failed to get {asset} balance: {e}")
 
-    async def get_market_price(self, asset: str) -> float:
-        """Get current market price"""
+    async def get_market_price(
+        self, asset: str, dex: Optional[str] = None
+    ) -> float:
+        """Get current market price for the asset on the selected dex.
+
+        If `dex` is None, infer from a HIP-3 namespaced asset name
+        (e.g. "felix:CRCL" -> dex="felix").
+        """
         if not self.is_connected:
             raise RuntimeError("Not connected to exchange")
 
         try:
-            # Get all mids (market prices)
-            all_mids = self.info.all_mids()
+            resolved_dex = self._infer_dex_from_asset(asset, dex)
+            all_mids = self.info.all_mids(dex=resolved_dex)
 
             # Find asset price
             if asset in all_mids:
@@ -284,13 +344,14 @@ class HyperliquidAdapter(ExchangeAdapter):
 
             from hyperliquid.utils.signing import OrderType as HLOrderType
 
-            rounded_size = self._round_size(order.asset, order.size)
+            order_dex = order.dex
+            rounded_size = self._round_size(order.asset, order.size, dex=order_dex)
 
             if order.order_type == OrderType.MARKET:
-                market_price = await self.get_market_price(order.asset)
+                market_price = await self.get_market_price(order.asset, dex=order_dex)
                 slippage = 1.01 if is_buy else 0.99
                 adjusted_price = self._round_price(
-                    order.asset, market_price * slippage
+                    order.asset, market_price * slippage, dex=order_dex
                 )
                 result = self.exchange.order(
                     name=order.asset,
@@ -301,7 +362,9 @@ class HyperliquidAdapter(ExchangeAdapter):
                     reduce_only=False,
                 )
             else:
-                rounded_price = self._round_price(order.asset, order.price)
+                rounded_price = self._round_price(
+                    order.asset, order.price, dex=order_dex
+                )
                 result = self.exchange.order(
                     name=order.asset,
                     is_buy=is_buy,
@@ -329,8 +392,10 @@ class HyperliquidAdapter(ExchangeAdapter):
         except Exception as e:
             raise RuntimeError(f"Failed to place {order.side.value} order: {e}")
 
-    async def cancel_order(self, exchange_order_id: str) -> bool:
-        """Cancel an order"""
+    async def cancel_order(
+        self, exchange_order_id: str, dex: Optional[str] = None
+    ) -> bool:
+        """Cancel an order. Searches `dex` (defaults to adapter dex) for the oid."""
         if not self.is_connected:
             raise RuntimeError("Not connected to exchange")
 
@@ -339,7 +404,9 @@ class HyperliquidAdapter(ExchangeAdapter):
             oid = int(exchange_order_id)
 
             # Find the asset name for this order by querying open orders
-            open_orders = self.info.open_orders(self.account_address)
+            open_orders = self.info.open_orders(
+                self.account_address, dex=self._dex_arg(dex)
+            )
             target_order = None
 
             for order in open_orders:
@@ -395,14 +462,16 @@ class HyperliquidAdapter(ExchangeAdapter):
             exchange_order_id=exchange_order_id,
         )
 
-    async def get_market_info(self, asset: str) -> MarketInfo:
-        """Get market information"""
+    async def get_market_info(
+        self, asset: str, dex: Optional[str] = None
+    ) -> MarketInfo:
+        """Get market information for the asset on the selected dex."""
         if not self.is_connected:
             raise RuntimeError("Not connected to exchange")
 
         try:
-            # Get market metadata
-            meta = self.info.meta()
+            resolved_dex = self._infer_dex_from_asset(asset, dex)
+            meta = self.info.meta(dex=resolved_dex)
             universe = meta.get("universe", [])
 
             for asset_info in universe:
@@ -411,8 +480,10 @@ class HyperliquidAdapter(ExchangeAdapter):
                     px_dec = max(0, self.PERP_PX_MAX_DECIMALS - sz_dec)
                     size_step = 10 ** (-sz_dec) if sz_dec > 0 else 1.0
                     try:
-                        mark = await self.get_market_price(asset)
-                        notional_min_size = self.MIN_NOTIONAL_USD / mark if mark > 0 else size_step
+                        mark = await self.get_market_price(asset, dex=resolved_dex)
+                        notional_min_size = (
+                            self.MIN_NOTIONAL_USD / mark if mark > 0 else size_step
+                        )
                     except Exception:
                         notional_min_size = size_step
                     return MarketInfo(
@@ -424,36 +495,47 @@ class HyperliquidAdapter(ExchangeAdapter):
                         size_precision=sz_dec,
                         is_active=True,
                         min_notional=self.MIN_NOTIONAL_USD,
+                        dex=resolved_dex or None,
                     )
 
-            raise ValueError(f"Asset {asset} not found")
+            raise ValueError(f"Asset {asset} not found on dex={resolved_dex!r}")
 
         except Exception as e:
             raise RuntimeError(f"Failed to get market info for {asset}: {e}")
 
-    async def get_open_orders(self) -> List[Order]:
-        """Get all open orders"""
+    async def get_open_orders(
+        self, dex: Optional[str] = None, all_dexes: bool = False
+    ) -> List[Order]:
+        """Get open orders.
+
+        By default returns orders for the adapter's configured dex (or main).
+        Set `all_dexes=True` to aggregate across every known HIP-3 dex.
+        """
         if not self.is_connected:
             return []
 
         try:
-            open_orders = self.info.open_orders(self.account_address)
-            orders = []
-
-            for order_info in open_orders:
-                order = Order(
-                    id=str(order_info.get("oid", "")),
-                    asset=order_info.get("coin", ""),
-                    side=OrderSide.BUY
-                    if order_info.get("side") == "B"
-                    else OrderSide.SELL,
-                    size=float(order_info.get("sz", 0)),
-                    order_type=OrderType.LIMIT,  # Hyperliquid default
-                    price=float(order_info.get("limitPx", 0)),
-                    status=OrderStatus.SUBMITTED,
-                    exchange_order_id=str(order_info.get("oid", "")),
-                )
-                orders.append(order)
+            dex_list = self._known_dexes if all_dexes else [self._dex_arg(dex)]
+            orders: List[Order] = []
+            for d in dex_list:
+                raw = self.info.open_orders(self.account_address, dex=d)
+                for order_info in raw or []:
+                    asset_name = order_info.get("coin", "")
+                    orders.append(
+                        Order(
+                            id=str(order_info.get("oid", "")),
+                            asset=asset_name,
+                            side=OrderSide.BUY
+                            if order_info.get("side") == "B"
+                            else OrderSide.SELL,
+                            size=float(order_info.get("sz", 0)),
+                            order_type=OrderType.LIMIT,
+                            price=float(order_info.get("limitPx", 0)),
+                            status=OrderStatus.SUBMITTED,
+                            exchange_order_id=str(order_info.get("oid", "")),
+                            dex=d or None,
+                        )
+                    )
 
             return orders
 
@@ -467,47 +549,48 @@ class HyperliquidAdapter(ExchangeAdapter):
             return False
 
         try:
-            # Simple health check - get account state
-            self.info.user_state(self.account_address)
+            self.info.user_state(self.account_address, dex=self._dex_arg(None))
             return True
         except Exception:
             return False
 
-    async def get_positions(self) -> List["Position"]:
-        """Get all current positions from Hyperliquid"""
+    async def get_positions(
+        self, dex: Optional[str] = None, all_dexes: bool = False
+    ) -> List["Position"]:
+        """Get current positions on the selected dex (or aggregated)."""
         if not self.is_connected:
             return []
 
         try:
-            # Import Position here to avoid circular imports
             from interfaces.strategy import Position
 
-            # Get user state which includes positions
-            user_state = self.info.user_state(self.account_address)
-            positions = []
+            dex_list = self._known_dexes if all_dexes else [self._dex_arg(dex)]
+            positions: List[Position] = []
+            for d in dex_list:
+                user_state = self.info.user_state(self.account_address, dex=d)
+                for pos_info in user_state.get("assetPositions", []):
+                    pos = pos_info.get("position", {})
+                    position_size = float(pos.get("szi", 0))
+                    if position_size == 0:
+                        continue
 
-            for pos_info in user_state.get("assetPositions", []):
-                pos = pos_info.get("position", {})
-                position_size = float(pos.get("szi", 0))
-                if position_size == 0:
-                    continue
+                    coin = pos.get("coin", "")
+                    entry_price = float(pos.get("entryPx") or 0)
+                    current_price = await self.get_market_price(coin, dex=d)
+                    current_value = abs(position_size) * current_price
+                    unrealized_pnl = float(pos.get("unrealizedPnl", 0))
 
-                coin = pos.get("coin", "")
-                entry_price = float(pos.get("entryPx") or 0)
-                current_price = await self.get_market_price(coin)
-                current_value = abs(position_size) * current_price
-                unrealized_pnl = float(pos.get("unrealizedPnl", 0))
-
-                positions.append(
-                    Position(
-                        asset=coin,
-                        size=position_size,
-                        entry_price=entry_price,
-                        current_value=current_value,
-                        unrealized_pnl=unrealized_pnl,
-                        timestamp=time.time(),
+                    positions.append(
+                        Position(
+                            asset=coin,
+                            size=position_size,
+                            entry_price=entry_price,
+                            current_value=current_value,
+                            unrealized_pnl=unrealized_pnl,
+                            timestamp=time.time(),
+                            dex=d or None,
+                        )
                     )
-                )
 
             return positions
 
@@ -515,14 +598,23 @@ class HyperliquidAdapter(ExchangeAdapter):
             print(f"❌ Error getting positions: {e}")
             return []
 
-    async def close_position(self, asset: str, size: Optional[float] = None) -> bool:
-        """Close a position by placing a market order"""
+    async def close_position(
+        self,
+        asset: str,
+        size: Optional[float] = None,
+        dex: Optional[str] = None,
+    ) -> bool:
+        """Close a position via market_close.
+
+        `dex` defaults to the dex inferred from the asset name (HIP-3 prefix)
+        or the adapter's configured dex.
+        """
         if not self.is_connected:
             return False
 
         try:
-            # Get current positions to determine position details
-            positions = await self.get_positions()
+            resolved_dex = self._infer_dex_from_asset(asset, dex)
+            positions = await self.get_positions(dex=resolved_dex)
             target_position = None
 
             for pos in positions:
@@ -531,7 +623,7 @@ class HyperliquidAdapter(ExchangeAdapter):
                     break
 
             if not target_position:
-                print(f"❌ No position found for {asset}")
+                print(f"❌ No position found for {asset} on dex={resolved_dex!r}")
                 return False
 
             if size is None:
@@ -539,7 +631,7 @@ class HyperliquidAdapter(ExchangeAdapter):
             else:
                 close_size = min(size, abs(target_position.size))
 
-            close_size = self._round_size(asset, close_size)
+            close_size = self._round_size(asset, close_size, dex=resolved_dex)
 
             result = self.exchange.market_close(coin=asset, sz=close_size)
 
@@ -554,8 +646,14 @@ class HyperliquidAdapter(ExchangeAdapter):
             print(f"❌ Error closing position {asset}: {e}")
             return False
 
-    async def get_account_metrics(self) -> Dict[str, Any]:
-        """Get account-level metrics for risk assessment"""
+    async def get_account_metrics(
+        self, dex: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Get account-level metrics for risk assessment.
+
+        `dex` selects which perp dex's clearinghouse state to read; defaults
+        to the adapter's configured dex.
+        """
         if not self.is_connected:
             return {
                 "total_value": 0.0,
@@ -566,8 +664,8 @@ class HyperliquidAdapter(ExchangeAdapter):
             }
 
         try:
-            # Get user state
-            user_state = self.info.user_state(self.account_address)
+            resolved_dex = self._dex_arg(dex)
+            user_state = self.info.user_state(self.account_address, dex=resolved_dex)
 
             total_value = 0.0
             margin_used = 0.0
@@ -581,7 +679,7 @@ class HyperliquidAdapter(ExchangeAdapter):
                 for p in user_state.get("assetPositions", [])
             )
 
-            positions = await self.get_positions()
+            positions = await self.get_positions(dex=resolved_dex)
             total_pnl = unrealized_pnl
 
             # Estimate drawdown percentage (this would be more sophisticated in production)

--- a/src/exchanges/hyperliquid/adapter.py
+++ b/src/exchanges/hyperliquid/adapter.py
@@ -126,25 +126,28 @@ class HyperliquidAdapter(ExchangeAdapter):
             return False
 
     def _load_asset_metadata(self) -> None:
+        """Discover dexes and eagerly load main + configured dex metadata.
+
+        209+ HIP-3 dexes makes a fan-out load at connect prohibitively slow.
+        We eagerly load only what's needed (main perp + the adapter's
+        configured `dex`); other dexes are lazy-loaded by `_ensure_dex_meta`
+        on first asset access.
+        """
         # Discover available HIP-3 dexes; main perp is "" by SDK convention.
         try:
             dexes = self.info.perp_dexs() or []
-            self._known_dexes = [""] + [d.get("name") for d in dexes if isinstance(d, dict) and d.get("name")]
+            self._known_dexes = [""] + [
+                d.get("name")
+                for d in dexes
+                if isinstance(d, dict) and d.get("name")
+            ]
         except Exception as e:
-            print(f"⚠️ Failed to discover perp dexes (HIP-3 support disabled): {e}")
+            print(f"⚠️ Failed to discover perp dexes (HIP-3 disabled): {e}")
             self._known_dexes = [""]
 
-        for dex_name in self._known_dexes:
-            try:
-                meta = self.info.meta(dex=dex_name)
-                for asset_info in meta.get("universe", []):
-                    name = asset_info.get("name")
-                    if name is not None:
-                        self._perp_sz_decimals[(dex_name, name)] = int(
-                            asset_info.get("szDecimals", 0)
-                        )
-            except Exception as e:
-                print(f"⚠️ Failed to load perp metadata for dex={dex_name!r}: {e}")
+        eager = {""} | ({self.dex} if self.dex else set())
+        for dex_name in eager:
+            self._ensure_dex_meta(dex_name)
 
         try:
             spot_meta = self.info.spot_meta()
@@ -187,6 +190,21 @@ class HyperliquidAdapter(ExchangeAdapter):
         except Exception as e:
             print(f"⚠️ Could not verify agent approval: {e}")
 
+    def _ensure_dex_meta(self, dex_name: str) -> None:
+        """Lazily load perp meta for `dex_name` if not already cached."""
+        if any(k[0] == dex_name for k in self._perp_sz_decimals):
+            return
+        try:
+            meta = self.info.meta(dex=dex_name)
+            for asset_info in meta.get("universe", []):
+                name = asset_info.get("name")
+                if name is not None:
+                    self._perp_sz_decimals[(dex_name, name)] = int(
+                        asset_info.get("szDecimals", 0)
+                    )
+        except Exception as e:
+            print(f"⚠️ Failed to load perp metadata for dex={dex_name!r}: {e}")
+
     def _is_spot(self, asset: str) -> bool:
         return "/" in asset or asset.startswith("@")
 
@@ -218,6 +236,8 @@ class HyperliquidAdapter(ExchangeAdapter):
 
         resolved = self._infer_dex_from_asset(asset, dex)
         key = (resolved, asset)
+        if key not in self._perp_sz_decimals:
+            self._ensure_dex_meta(resolved)
         if key not in self._perp_sz_decimals:
             raise RuntimeError(
                 f"Missing perp precision metadata for {asset} on dex={resolved!r}"
@@ -509,7 +529,9 @@ class HyperliquidAdapter(ExchangeAdapter):
         """Get open orders.
 
         By default returns orders for the adapter's configured dex (or main).
-        Set `all_dexes=True` to aggregate across every known HIP-3 dex.
+        `all_dexes=True` aggregates across every known HIP-3 dex; with 200+
+        dexes on mainnet this issues one Info request per dex serially. Use
+        sparingly — prefer narrowing via `dex=` for hot paths.
         """
         if not self.is_connected:
             return []
@@ -557,7 +579,11 @@ class HyperliquidAdapter(ExchangeAdapter):
     async def get_positions(
         self, dex: Optional[str] = None, all_dexes: bool = False
     ) -> List["Position"]:
-        """Get current positions on the selected dex (or aggregated)."""
+        """Get current positions on the selected dex (or aggregated).
+
+        `all_dexes=True` issues one user_state request per known dex serially;
+        cost grows with the number of HIP-3 dexes. Prefer `dex=` for hot paths.
+        """
         if not self.is_connected:
             return []
 

--- a/src/exchanges/hyperliquid/market_data.py
+++ b/src/exchanges/hyperliquid/market_data.py
@@ -49,9 +49,13 @@ class HyperliquidMarketData:
         self._asset_dex: Dict[str, str] = {}
         self._dex_subscriptions: set = set()
 
-        # Generic channel subscription callbacks keyed by subscription type
-        # (e.g. "bbo", "activeAssetCtx", "userTwapSliceFills").
-        self._channel_callbacks: Dict[str, List[Callable[[Dict[str, Any]], Any]]] = {}
+        # Generic channel subscription state. Callbacks are keyed by
+        # (type, coin) so multiple per-coin subscriptions on the same channel
+        # type don't cross-fire. Subscriptions list is replayed on reconnect.
+        self._channel_callbacks: Dict[
+            tuple, List[Callable[[Dict[str, Any]], Any]]
+        ] = {}
+        self._channel_subscriptions: List[Dict[str, Any]] = []
 
     def _resolve_ws_url(self) -> str:
         url = self.endpoint_router.get_endpoint_for_method("subscribe_price")
@@ -168,15 +172,14 @@ class HyperliquidMarketData:
         subscription: Dict[str, Any],
         callback: Callable[[Dict[str, Any]], Any],
     ) -> None:
-        """Generic subscription helper for HIP-3-era channels (bbo,
-        activeAssetCtx, activeAssetData, userTwapSliceFills, userTwapHistory,
-        webData3, allDexsAssetCtxs, allDexsClearinghouseState, etc.).
+        """Generic subscription for HIP-3-era channels (bbo, activeAssetCtx,
+        activeAssetData, userTwapSliceFills, userTwapHistory, webData3,
+        allDexsAssetCtxs, allDexsClearinghouseState, etc.).
 
-        The caller passes the full `subscription` dict (e.g. {"type": "bbo",
-        "coin": "BTC"}). The callback receives the raw `data` payload of every
-        matching message. Channel name matching is permissive: the message's
-        "channel" field is matched against `subscription["type"]` exactly,
-        with the known alias activeAssetCtx -> activeSpotAssetCtx for spot.
+        Pass the full `subscription` dict (e.g. {"type": "bbo", "coin": "BTC"}).
+        Callbacks are keyed by (type, coin) so per-coin subscriptions don't
+        cross-fire. activeSpotAssetCtx is aliased to activeAssetCtx for
+        callers using the generic name.
         """
         if not (self.ws and self.running):
             raise RuntimeError("WebSocket not connected")
@@ -185,7 +188,9 @@ class HyperliquidMarketData:
         if not sub_type:
             raise ValueError("subscription must have a 'type'")
 
-        self._channel_callbacks.setdefault(sub_type, []).append(callback)
+        coin = subscription.get("coin")
+        self._channel_callbacks.setdefault((sub_type, coin), []).append(callback)
+        self._channel_subscriptions.append(dict(subscription))
         await self.ws.send(
             json.dumps({"method": "subscribe", "subscription": subscription})
         )
@@ -255,14 +260,25 @@ class HyperliquidMarketData:
             await self._handle_price_update(data.get("data", {}))
             return
 
-        # Map activeSpotAssetCtx -> activeAssetCtx for callers that subscribed
-        # via the generic name; SDK 0.16+ delivers spot under a distinct channel
-        # but the subscription type is still "activeAssetCtx".
-        lookup = "activeAssetCtx" if channel == "activeSpotAssetCtx" else channel
-        callbacks = self._channel_callbacks.get(lookup) or []
-        for cb in callbacks:
+        # activeSpotAssetCtx is delivered under that channel name but callers
+        # subscribe via the generic "activeAssetCtx" type; alias them.
+        lookup_type = (
+            "activeAssetCtx" if channel == "activeSpotAssetCtx" else channel
+        )
+
+        payload = data.get("data", {})
+        # Per-coin filtering: a callback registered with coin=X only fires for
+        # messages that match that coin (or for channels with no coin scope).
+        msg_coin = payload.get("coin") if isinstance(payload, dict) else None
+        recipients = []
+        for (sub_type, sub_coin), cbs in self._channel_callbacks.items():
+            if sub_type != lookup_type:
+                continue
+            if sub_coin is None or msg_coin is None or sub_coin == msg_coin:
+                recipients.extend(cbs)
+
+        for cb in recipients:
             try:
-                payload = data.get("data", {})
                 if asyncio.iscoroutinefunction(cb):
                     asyncio.create_task(cb(payload))
                 else:
@@ -328,14 +344,17 @@ class HyperliquidMarketData:
             return False
 
     async def _resubscribe_all(self) -> None:
-        """Re-subscribe across every dex previously seen after reconnection."""
+        """Replay every subscription (allMids per dex + generic channels)."""
 
-        if not (self.subscribed_assets and self.ws and self.running):
+        if not (self.ws and self.running):
             return
 
-        prior = set(self._dex_subscriptions) or {""}
+        # Replay per-dex allMids subs.
+        prior_dexes = set(self._dex_subscriptions) or (
+            {""} if self.subscribed_assets else set()
+        )
         self._dex_subscriptions.clear()
-        for d in prior:
+        for d in prior_dexes:
             subscription: Dict[str, Any] = {"type": "allMids"}
             if d:
                 subscription["dex"] = d
@@ -343,8 +362,16 @@ class HyperliquidMarketData:
                 json.dumps({"method": "subscribe", "subscription": subscription})
             )
             self._dex_subscriptions.add(d)
+
+        # Replay generic channels (bbo, activeAssetCtx, ...).
+        for sub in self._channel_subscriptions:
+            await self.ws.send(
+                json.dumps({"method": "subscribe", "subscription": sub})
+            )
+
         print(
-            f"🔄 Re-subscribed across {len(prior)} dex(es) for {len(self.subscribed_assets)} assets"
+            f"🔄 Re-subscribed: {len(prior_dexes)} dex(es), "
+            f"{len(self._channel_subscriptions)} generic channel(s)"
         )
 
     def get_status(self) -> Dict[str, Any]:

--- a/src/exchanges/hyperliquid/market_data.py
+++ b/src/exchanges/hyperliquid/market_data.py
@@ -44,6 +44,15 @@ class HyperliquidMarketData:
         # Endpoint router for smart routing
         self.endpoint_router = get_endpoint_router(testnet)
 
+        # HIP-3 dex tracking: which dex an asset is subscribed via, and which
+        # dex-scoped allMids subscriptions have already been sent.
+        self._asset_dex: Dict[str, str] = {}
+        self._dex_subscriptions: set = set()
+
+        # Generic channel subscription callbacks keyed by subscription type
+        # (e.g. "bbo", "activeAssetCtx", "userTwapSliceFills").
+        self._channel_callbacks: Dict[str, List[Callable[[Dict[str, Any]], Any]]] = {}
+
     def _resolve_ws_url(self) -> str:
         url = self.endpoint_router.get_endpoint_for_method("subscribe_price")
         if url:
@@ -96,22 +105,49 @@ class HyperliquidMarketData:
         print("🔌 Disconnected from Hyperliquid WebSocket")
 
     async def subscribe_price_updates(
-        self, asset: str, callback: Callable[[MarketData], None]
+        self,
+        asset: str,
+        callback: Callable[[MarketData], None],
+        dex: Optional[str] = None,
     ) -> None:
-        """Subscribe to price updates for an asset"""
+        """Subscribe to allMids price updates for an asset.
+
+        `dex` selects a HIP-3 dex; if not given and the asset name is
+        namespaced (e.g. "felix:CRCL"), the prefix is used. allMids on the
+        main dex returns spot mids too, so spot subscriptions stay there.
+        """
+        resolved_dex = (
+            dex
+            if dex is not None
+            else (
+                asset.split(":", 1)[0]
+                if ":" in asset and not asset.startswith("@")
+                else ""
+            )
+        )
+        self._asset_dex[asset] = resolved_dex
 
         if asset not in self.price_callbacks:
             self.price_callbacks[asset] = []
-
         self.price_callbacks[asset].append(callback)
         self.subscribed_assets.add(asset)
 
-        # Subscribe via WebSocket
-        if self.ws and self.running:
-            subscribe_msg = {"method": "subscribe", "subscription": {"type": "allMids"}}
-            await self.ws.send(json.dumps(subscribe_msg))
+        if (
+            self.ws
+            and self.running
+            and resolved_dex not in self._dex_subscriptions
+        ):
+            subscription: Dict[str, Any] = {"type": "allMids"}
+            if resolved_dex:
+                subscription["dex"] = resolved_dex
+            await self.ws.send(
+                json.dumps({"method": "subscribe", "subscription": subscription})
+            )
+            self._dex_subscriptions.add(resolved_dex)
 
-        print(f"📊 Subscribed to {asset} price updates")
+        print(
+            f"📊 Subscribed to {asset} price updates (dex={resolved_dex or 'main'})"
+        )
 
     async def unsubscribe_price_updates(
         self, asset: str, callback: Callable[[MarketData], None]
@@ -126,6 +162,34 @@ class HyperliquidMarketData:
                     self.subscribed_assets.discard(asset)
             except ValueError:
                 pass
+
+    async def subscribe_channel(
+        self,
+        subscription: Dict[str, Any],
+        callback: Callable[[Dict[str, Any]], Any],
+    ) -> None:
+        """Generic subscription helper for HIP-3-era channels (bbo,
+        activeAssetCtx, activeAssetData, userTwapSliceFills, userTwapHistory,
+        webData3, allDexsAssetCtxs, allDexsClearinghouseState, etc.).
+
+        The caller passes the full `subscription` dict (e.g. {"type": "bbo",
+        "coin": "BTC"}). The callback receives the raw `data` payload of every
+        matching message. Channel name matching is permissive: the message's
+        "channel" field is matched against `subscription["type"]` exactly,
+        with the known alias activeAssetCtx -> activeSpotAssetCtx for spot.
+        """
+        if not (self.ws and self.running):
+            raise RuntimeError("WebSocket not connected")
+
+        sub_type = subscription.get("type")
+        if not sub_type:
+            raise ValueError("subscription must have a 'type'")
+
+        self._channel_callbacks.setdefault(sub_type, []).append(callback)
+        await self.ws.send(
+            json.dumps({"method": "subscribe", "subscription": subscription})
+        )
+        print(f"📡 Subscribed to channel: {subscription}")
 
     def get_latest_price(self, asset: str) -> Optional[float]:
         """Get latest cached price for an asset"""
@@ -186,9 +250,25 @@ class HyperliquidMarketData:
     async def _process_message(self, data: Dict[str, Any]) -> None:
         """Process incoming WebSocket message"""
 
-        # Handle different message types
-        if data.get("channel") == "allMids":
+        channel = data.get("channel")
+        if channel == "allMids":
             await self._handle_price_update(data.get("data", {}))
+            return
+
+        # Map activeSpotAssetCtx -> activeAssetCtx for callers that subscribed
+        # via the generic name; SDK 0.16+ delivers spot under a distinct channel
+        # but the subscription type is still "activeAssetCtx".
+        lookup = "activeAssetCtx" if channel == "activeSpotAssetCtx" else channel
+        callbacks = self._channel_callbacks.get(lookup) or []
+        for cb in callbacks:
+            try:
+                payload = data.get("data", {})
+                if asyncio.iscoroutinefunction(cb):
+                    asyncio.create_task(cb(payload))
+                else:
+                    cb(payload)
+            except Exception as e:
+                print(f"❌ Error in channel callback for {channel}: {e}")
 
     async def _handle_price_update(self, price_data: Dict[str, Any]) -> None:
         """Handle price update message"""
@@ -248,13 +328,24 @@ class HyperliquidMarketData:
             return False
 
     async def _resubscribe_all(self) -> None:
-        """Re-subscribe to all assets after reconnection"""
+        """Re-subscribe across every dex previously seen after reconnection."""
 
-        if self.subscribed_assets and self.ws and self.running:
-            subscribe_msg = {"method": "subscribe", "subscription": {"type": "allMids"}}
-            await self.ws.send(json.dumps(subscribe_msg))
+        if not (self.subscribed_assets and self.ws and self.running):
+            return
 
-            print(f"🔄 Re-subscribed to {len(self.subscribed_assets)} assets")
+        prior = set(self._dex_subscriptions) or {""}
+        self._dex_subscriptions.clear()
+        for d in prior:
+            subscription: Dict[str, Any] = {"type": "allMids"}
+            if d:
+                subscription["dex"] = d
+            await self.ws.send(
+                json.dumps({"method": "subscribe", "subscription": subscription})
+            )
+            self._dex_subscriptions.add(d)
+        print(
+            f"🔄 Re-subscribed across {len(prior)} dex(es) for {len(self.subscribed_assets)} assets"
+        )
 
     def get_status(self) -> Dict[str, Any]:
         """Get market data provider status"""

--- a/src/interfaces/exchange.py
+++ b/src/interfaces/exchange.py
@@ -38,7 +38,11 @@ class OrderStatus(Enum):
 
 @dataclass
 class Order:
-    """Order representation"""
+    """Order representation.
+
+    `dex` selects a HIP-3 builder-deployed perp dex when not None; default
+    None means the main perp dex (or spot, depending on `is_spot`).
+    """
 
     id: str
     asset: str
@@ -51,6 +55,8 @@ class Order:
     average_fill_price: float = 0.0
     exchange_order_id: Optional[str] = None
     created_at: float = 0.0  # Timestamp when order was created
+    dex: Optional[str] = None
+    is_spot: bool = False
 
 
 @dataclass
@@ -75,6 +81,7 @@ class MarketInfo:
     size_precision: int
     is_active: bool
     min_notional: float = 10.0
+    dex: Optional[str] = None
 
 
 class ExchangeAdapter(ABC):

--- a/src/interfaces/exchange.py
+++ b/src/interfaces/exchange.py
@@ -56,7 +56,6 @@ class Order:
     exchange_order_id: Optional[str] = None
     created_at: float = 0.0  # Timestamp when order was created
     dex: Optional[str] = None
-    is_spot: bool = False
 
 
 @dataclass

--- a/src/interfaces/strategy.py
+++ b/src/interfaces/strategy.py
@@ -22,7 +22,10 @@ class SignalType(Enum):
 
 @dataclass
 class TradingSignal:
-    """A trading signal from a strategy"""
+    """A trading signal from a strategy.
+
+    `dex` selects a HIP-3 builder-deployed perp dex (None = main perp dex).
+    """
 
     signal_type: SignalType
     asset: str
@@ -30,6 +33,8 @@ class TradingSignal:
     price: Optional[float] = None  # None = market order
     reason: str = ""
     metadata: Dict[str, Any] = None
+    dex: Optional[str] = None
+    is_spot: bool = False
 
     def __post_init__(self):
         if self.metadata is None:
@@ -47,6 +52,7 @@ class MarketData:
     bid: Optional[float] = None
     ask: Optional[float] = None
     volatility: Optional[float] = None
+    dex: Optional[str] = None
 
 
 @dataclass
@@ -59,6 +65,7 @@ class Position:
     current_value: float
     unrealized_pnl: float
     timestamp: float
+    dex: Optional[str] = None
 
 
 class TradingStrategy(ABC):

--- a/src/interfaces/strategy.py
+++ b/src/interfaces/strategy.py
@@ -34,7 +34,6 @@ class TradingSignal:
     reason: str = ""
     metadata: Dict[str, Any] = None
     dex: Optional[str] = None
-    is_spot: bool = False
 
     def __post_init__(self):
         if self.metadata is None:


### PR DESCRIPTION
Adds HIP-3 builder-deployed perp dex routing throughout the bot. Default behaviour (no \`dex\` set) is unchanged: main perp dex only.

## What changes

### Schema
\`Order\`, \`MarketData\`, \`Position\`, \`TradingSignal\` get an optional \`dex\` field. \`GridConfig\` and \`ExchangeConfig\` gain optional \`dex\` and \`is_spot\`. \`MarketInfo\` gains \`dex\`.

### Adapter
- \`HyperliquidAdapter(dex=None)\` constructor argument; \`account_address\` factory wiring preserved.
- Discovers HIP-3 dexes via \`info.perp_dexs()\` at connect (209 on testnet today). Per-dex \`szDecimals\` cache keyed by \`(dex_name, asset)\`.
- HIP-3 asset names are namespaced (\`felix:CRCL\`); dex is auto-inferred from the prefix when not passed.
- All Info methods thread the dex parameter: \`all_mids\`, \`user_state\`, \`open_orders\`, \`meta\`. \`get_open_orders\`/\`get_positions\` add \`all_dexes=True\` for cross-dex sweep.
- New \`list_perp_dexes()\` helper.

### Market data
- \`subscribe_price_updates(asset, callback, dex=None)\` routes \`allMids\` per-dex.
- New \`subscribe_channel()\` for HIP-3-era channels (\`bbo\`, \`activeAssetCtx\`, \`activeAssetData\`, \`userTwapSliceFills\`, \`webData3\`, ...). Maps \`activeSpotAssetCtx\` -> \`activeAssetCtx\` for callers.
- \`_resubscribe_all\` replays per-dex subscriptions on reconnect.

### Learning examples
- \`02_market_data/get_all_prices.py\`, \`03_account_info/get_user_state.py\`, \`get_open_orders.py\`: optional \`DEX\` env var.
- \`05_funding/get_funding_rates.py\`: HIP-3 sweep via \`DEXES\` env (comma list, or \`all\`); was previously dex-0 only.

## Verified live on testnet
Master 0xD876…C56e, agent 0x8b97…728A:
- 209 perp dexes discovered at connect.
- BTC main: mid \$77,078, dex=None, price_precision=1.
- felix:CRCL (HIP-3): mid \$130, dex=felix, price_precision=4, size_precision=2, min_order_size 0.077 (≈\$10 notional).
- WS: 10 BTC main ticks + 10 felix:CRCL ticks + 5 bbo updates in 10s.
- Limit place/cancel regression passes (oid 52173206183).
- \`DEXES=,felix,unit get_funding_rates.py\` sweeps 3 dexes.

## Test plan
- [ ] \`uv sync\` clean
- [ ] \`uv run learning_examples/02_market_data/get_market_metadata.py\` (no env)
- [ ] \`DEX=felix uv run learning_examples/02_market_data/get_all_prices.py\`
- [ ] \`DEXES=,felix uv run learning_examples/05_funding/get_funding_rates.py\`
- [ ] \`uv run src/run_bot.py --validate bots/btc_conservative.yaml\`

## Out of scope (deferred)
- Threading \`dex\` through every other learning example (websockets, copy trading, place_limit_order). Will batch in a follow-up.
- Updating \`risk_manager\` and \`engine\` to be dex-aware (separate PR with the SDK 0.21 \`grouping=positionTpsl\` work).
- \`info.spot_meta()\` HIP-3 changes (no protocol change here yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for HIP-3 DEX selection, enabling trading across multiple builder-deployed perpetual exchanges.
  * Multi-DEX market data subscriptions now available.
  * New method to list available perpetual DEXes.

* **Improvements**
  * Enhanced price display precision from 2 to 4 decimal places.
  * Added spot asset routing support alongside perpetual markets.
  * Extended configuration options for DEX and asset type selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->