### PR TITLE
feat(engine): real fills via userFills + grouped TPSL at fill time

### DIFF
--- a/bots/btc_conservative.yaml
+++ b/bots/btc_conservative.yaml
@@ -40,10 +40,20 @@ risk_management:
   # Stop Loss: Automatically close positions when loss exceeds threshold
   stop_loss_enabled: false        # Options: true/false - Enable automatic stop loss
   stop_loss_pct: 8.0             # Percentage loss before closing position (range: 1-20%)
-  
-  # Take Profit: Automatically close positions when profit exceeds threshold  
+
+  # Take Profit: Automatically close positions when profit exceeds threshold
   take_profit_enabled: false      # Options: true/false - Enable automatic take profit
   take_profit_pct: 25.0          # Percentage profit before closing position (range: 5-100%)
+
+  # tpsl_mode: how stop_loss / take_profit are enforced.
+  #   "polling" (default): engine polls unrealized_pnl per price tick and
+  #                        emits a CLOSE signal when the threshold is crossed.
+  #   "grouped":           SDK 0.21+ positionTpsl. At fill time the adapter
+  #                        registers a paired TP/SL trigger pair (reduce-only
+  #                        market) sized to fully close the position. The
+  #                        matching engine fires whichever leg hits first; no
+  #                        polling, no race.
+  tpsl_mode: "polling"
   
   # Account Protection: Portfolio-level risk controls
   max_drawdown_pct: 15.0         # Stop all trading if account drawdown exceeds % (range: 5-50%)

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -55,6 +55,12 @@ class TradingEngine:
         # State tracking
         self.current_positions: List[Position] = []
         self.pending_orders: Dict[str, Order] = {}
+        # exchange_order_id -> originating signal, used to correlate userFills
+        # events back to the strategy that triggered them.
+        self._signals_by_oid: Dict[str, TradingSignal] = {}
+        # asset -> True once a position is open for it; used to decide whether
+        # a fill represents an opening trade that needs paired TP/SL armed.
+        self._tpsl_armed: Dict[str, bool] = {}
         self.executed_trades = 0
         self.total_pnl = 0.0
 
@@ -178,6 +184,14 @@ class TradingEngine:
         # Subscribe to market data for strategy asset
         asset = self.config.get("strategy", {}).get("symbol", "BTC")
         await self.market_data.subscribe_price_updates(asset, self._handle_price_update)
+
+        # Subscribe to real fill events; on_trade_executed now fires when the
+        # matching engine actually fills, not when an oid comes back from
+        # place_order. Required for any strategy that compounds on fills.
+        await self.market_data.subscribe_channel(
+            {"type": "userFills", "user": self.exchange.account_address},
+            self._handle_user_fill,
+        )
 
         # Main trading loop
         await self._trading_loop()
@@ -377,6 +391,7 @@ class TradingEngine:
             order_type=OrderType.LIMIT if signal.price else OrderType.MARKET,
             price=signal.price,
             created_at=current_time,
+            dex=signal.dex,
         )
 
         # Place order with exchange
@@ -391,12 +406,97 @@ class TradingEngine:
             f"📝 Placed {order.side.value} order: {order.size} {order.asset} @ ${order.price}"
         )
 
-        # Notify strategy
-        if self.strategy:
-            # Simulate immediate execution for now (real implementation would track fills)
-            executed_price = order.price or 0.0
-            self.strategy.on_trade_executed(signal, executed_price, order.size)
-            self.executed_trades += 1
+        # Track signal so the userFills callback can correlate the real fill.
+        self._signals_by_oid[exchange_order_id] = signal
+
+    async def _handle_user_fill(self, payload: Dict[str, Any]) -> None:
+        """Handle a userFills WS event.
+
+        The userFills subscription delivers a snapshot of historical fills on
+        connect (isSnapshot=True) followed by live update messages. We skip
+        the snapshot to avoid re-acting to fills that landed before the
+        engine started (false TPSL arms, double on_trade_executed calls).
+
+        Each fill carries: coin, oid, side, sz, px, dir ("Open Long"/
+        "Close Long"/"Open Short"/"Close Short"), startPosition, hash, time,
+        fee. We notify the strategy and, on opening fills with grouped
+        tpsl_mode, arm a paired TP/SL via the adapter.
+        """
+        if not self.running or not self.strategy or not self.exchange:
+            return
+
+        if payload.get("isSnapshot"):
+            return
+
+        fills = payload.get("fills") or []
+        for fill in fills:
+            try:
+                # Fill events deliver oid as int; the adapter returns it as
+                # str — normalize both sides on the str form.
+                oid = str(fill.get("oid", ""))
+                signal = self._signals_by_oid.pop(oid, None)
+                px = float(fill.get("px", 0))
+                sz = float(fill.get("sz", 0))
+
+                if signal is not None:
+                    self.strategy.on_trade_executed(signal, px, sz)
+                    self.executed_trades += 1
+                    self.logger.info(
+                        f"💱 Filled {fill.get('coin')} {fill.get('side')} "
+                        f"sz={sz} @ ${px} oid={oid}"
+                    )
+
+                direction = fill.get("dir") or ""
+                if "Open" in direction:
+                    await self._maybe_arm_grouped_tpsl(fill)
+                elif "Close" in direction:
+                    self._tpsl_armed.pop(fill.get("coin"), None)
+            except Exception as e:
+                self.logger.error(f"❌ Error handling fill: {e}")
+
+    async def _maybe_arm_grouped_tpsl(self, fill: Dict[str, Any]) -> None:
+        """Place paired TP/SL trigger orders if tpsl_mode == 'grouped'.
+
+        Idempotent per asset: skips if already armed since last close.
+        Requires the position to be present in get_positions (race-safe).
+        """
+        risk_cfg = self.config.get("risk_management", {})
+        if risk_cfg.get("tpsl_mode", "polling") != "grouped":
+            return
+
+        coin = fill.get("coin")
+        if not coin or self._tpsl_armed.get(coin):
+            return
+
+        positions = await self.exchange.get_positions()
+        position = next((p for p in positions if p.asset == coin), None)
+        if position is None or position.size == 0:
+            return
+
+        sl_pct = risk_cfg.get("stop_loss_pct") if risk_cfg.get("stop_loss_enabled") else None
+        tp_pct = risk_cfg.get("take_profit_pct") if risk_cfg.get("take_profit_enabled") else None
+        if sl_pct is None and tp_pct is None:
+            return
+
+        is_long = position.size > 0
+        entry = position.entry_price
+        tp_price = entry * (1 + tp_pct / 100) if tp_pct is not None and is_long else (
+            entry * (1 - tp_pct / 100) if tp_pct is not None else None
+        )
+        sl_price = entry * (1 - sl_pct / 100) if sl_pct is not None and is_long else (
+            entry * (1 + sl_pct / 100) if sl_pct is not None else None
+        )
+
+        try:
+            await self.exchange.register_position_tpsl(
+                coin, position.size, tp_price=tp_price, sl_price=sl_price
+            )
+            self._tpsl_armed[coin] = True
+            self.logger.info(
+                f"🎯 Armed grouped TP/SL on {coin}: tp={tp_price} sl={sl_price}"
+            )
+        except Exception as e:
+            self.logger.error(f"❌ Failed to arm grouped TP/SL on {coin}: {e}")
 
     async def _close_positions(self, signal: TradingSignal) -> None:
         """Close positions (e.g., cancel all orders for rebalancing)"""

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -7,7 +7,7 @@ Clean, focused responsibility - no confusing naming like "enhanced" or "advanced
 
 import asyncio
 import time
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 import logging
 
 from interfaces.strategy import (
@@ -55,12 +55,15 @@ class TradingEngine:
         # State tracking
         self.current_positions: List[Position] = []
         self.pending_orders: Dict[str, Order] = {}
-        # exchange_order_id -> originating signal, used to correlate userFills
-        # events back to the strategy that triggered them.
-        self._signals_by_oid: Dict[str, TradingSignal] = {}
-        # asset -> True once a position is open for it; used to decide whether
-        # a fill represents an opening trade that needs paired TP/SL armed.
-        self._tpsl_armed: Dict[str, bool] = {}
+        # exchange_order_id -> (originating signal, created_at). Used to
+        # correlate userFills back to the strategy. Periodically swept so
+        # never-filled cancelled orders don't leak.
+        self._signals_by_oid: Dict[str, Tuple[TradingSignal, float]] = {}
+        # asset -> set of trigger oids registered for that asset's position.
+        # Used to (a) cancel-and-rearm on partial-fill, and (b) detect
+        # external cancellation so we can re-arm.
+        self._tpsl_oids: Dict[str, List[str]] = {}
+        self._signals_oid_ttl_sec = 24 * 3600
         self.executed_trades = 0
         self.total_pnl = 0.0
 
@@ -407,7 +410,7 @@ class TradingEngine:
         )
 
         # Track signal so the userFills callback can correlate the real fill.
-        self._signals_by_oid[exchange_order_id] = signal
+        self._signals_by_oid[exchange_order_id] = (signal, current_time)
 
     async def _handle_user_fill(self, payload: Dict[str, Any]) -> None:
         """Handle a userFills WS event.
@@ -434,11 +437,12 @@ class TradingEngine:
                 # Fill events deliver oid as int; the adapter returns it as
                 # str — normalize both sides on the str form.
                 oid = str(fill.get("oid", ""))
-                signal = self._signals_by_oid.pop(oid, None)
+                tracked = self._signals_by_oid.pop(oid, None)
                 px = float(fill.get("px", 0))
                 sz = float(fill.get("sz", 0))
 
-                if signal is not None:
+                if tracked is not None:
+                    signal, _placed_at = tracked
                     self.strategy.on_trade_executed(signal, px, sz)
                     self.executed_trades += 1
                     self.logger.info(
@@ -450,22 +454,47 @@ class TradingEngine:
                 if "Open" in direction:
                     await self._maybe_arm_grouped_tpsl(fill)
                 elif "Close" in direction:
-                    self._tpsl_armed.pop(fill.get("coin"), None)
+                    self._tpsl_oids.pop(fill.get("coin"), None)
             except Exception as e:
-                self.logger.error(f"❌ Error handling fill: {e}")
+                self.logger.error(
+                    f"❌ Error handling fill {fill}: {e}"
+                )
+
+    @staticmethod
+    def _tpsl_prices(
+        entry: float,
+        is_long: bool,
+        tp_pct: Optional[float],
+        sl_pct: Optional[float],
+    ) -> Tuple[Optional[float], Optional[float]]:
+        """Compute absolute TP/SL prices from entry and percentage offsets.
+
+        For a long: TP is above entry, SL is below. For a short: inverted.
+        """
+        if tp_pct is not None:
+            tp = entry * (1 + tp_pct / 100) if is_long else entry * (1 - tp_pct / 100)
+        else:
+            tp = None
+        if sl_pct is not None:
+            sl = entry * (1 - sl_pct / 100) if is_long else entry * (1 + sl_pct / 100)
+        else:
+            sl = None
+        return tp, sl
 
     async def _maybe_arm_grouped_tpsl(self, fill: Dict[str, Any]) -> None:
-        """Place paired TP/SL trigger orders if tpsl_mode == 'grouped'.
+        """Place paired TP/SL trigger orders for the live position.
 
-        Idempotent per asset: skips if already armed since last close.
-        Requires the position to be present in get_positions (race-safe).
+        Re-arms on every "Open" fill against the *current* position size so
+        partial fills don't leave added size unprotected. Cancels the prior
+        trigger pair before placing the new one. No-op when the asset isn't
+        actually open or grouped tpsl_mode isn't enabled.
         """
         risk_cfg = self.config.get("risk_management", {})
         if risk_cfg.get("tpsl_mode", "polling") != "grouped":
             return
 
         coin = fill.get("coin")
-        if not coin or self._tpsl_armed.get(coin):
+        if not coin:
             return
 
         positions = await self.exchange.get_positions()
@@ -478,22 +507,33 @@ class TradingEngine:
         if sl_pct is None and tp_pct is None:
             return
 
-        is_long = position.size > 0
-        entry = position.entry_price
-        tp_price = entry * (1 + tp_pct / 100) if tp_pct is not None and is_long else (
-            entry * (1 - tp_pct / 100) if tp_pct is not None else None
-        )
-        sl_price = entry * (1 - sl_pct / 100) if sl_pct is not None and is_long else (
-            entry * (1 + sl_pct / 100) if sl_pct is not None else None
+        # Cancel any prior trigger pair so size and prices reflect the new
+        # entry / position size after this partial.
+        for prior_oid in self._tpsl_oids.pop(coin, []):
+            try:
+                await self.exchange.cancel_order(prior_oid)
+            except Exception as e:
+                self.logger.debug(f"prior TPSL cancel skipped ({prior_oid}): {e}")
+
+        tp_price, sl_price = self._tpsl_prices(
+            position.entry_price, position.size > 0, tp_pct, sl_pct
         )
 
         try:
             await self.exchange.register_position_tpsl(
                 coin, position.size, tp_price=tp_price, sl_price=sl_price
             )
-            self._tpsl_armed[coin] = True
+            # Re-read open orders to capture the freshly placed trigger oids
+            # so we can cancel-and-rearm or detect external cancellation.
+            open_orders = await self.exchange.get_open_orders(dex=position.dex)
+            self._tpsl_oids[coin] = [
+                o.exchange_order_id
+                for o in open_orders
+                if o.asset == coin and o.exchange_order_id
+            ]
             self.logger.info(
-                f"🎯 Armed grouped TP/SL on {coin}: tp={tp_price} sl={sl_price}"
+                f"🎯 Armed grouped TP/SL on {coin}: "
+                f"tp={tp_price} sl={sl_price} sz={position.size}"
             )
         except Exception as e:
             self.logger.error(f"❌ Failed to arm grouped TP/SL on {coin}: {e}")
@@ -515,6 +555,8 @@ class TradingEngine:
 
                 # Update order statuses (simplified)
                 await self._update_order_statuses()
+                self._sweep_signals_by_oid()
+                await self._recover_orphaned_tpsl()
 
                 # Log status
                 if self.executed_trades > 0:
@@ -523,6 +565,53 @@ class TradingEngine:
             except Exception as e:
                 self.logger.error(f"❌ Error in trading loop: {e}")
                 await asyncio.sleep(60)
+
+    def _sweep_signals_by_oid(self) -> None:
+        """Drop tracked signals older than the TTL.
+
+        Orders that get cancelled out-of-band (or never fill) never trigger
+        the userFills cleanup; without this sweep, the dict grows unbounded.
+        """
+        cutoff = time.time() - self._signals_oid_ttl_sec
+        stale = [oid for oid, (_, t) in self._signals_by_oid.items() if t < cutoff]
+        for oid in stale:
+            self._signals_by_oid.pop(oid, None)
+
+    async def _recover_orphaned_tpsl(self) -> None:
+        """Re-arm grouped TPSL when the registered trigger orders are gone.
+
+        If the user cancels the trigger pair via the UI while the position is
+        still open, our `_tpsl_oids` map keeps stale ids that no longer exist
+        on the exchange. Detect that and re-arm so the position isn't silently
+        unprotected.
+        """
+        risk_cfg = self.config.get("risk_management", {})
+        if risk_cfg.get("tpsl_mode", "polling") != "grouped":
+            return
+        if not self._tpsl_oids:
+            return
+        try:
+            positions = await self.exchange.get_positions()
+            open_orders = await self.exchange.get_open_orders()
+        except Exception as e:
+            self.logger.debug(f"orphan-recovery skipped: {e}")
+            return
+
+        live_oids = {o.exchange_order_id for o in open_orders if o.exchange_order_id}
+        for coin, oids in list(self._tpsl_oids.items()):
+            position = next((p for p in positions if p.asset == coin), None)
+            if position is None or position.size == 0:
+                self._tpsl_oids.pop(coin, None)
+                continue
+            if not any(o in live_oids for o in oids):
+                self.logger.warning(
+                    f"⚠️ TPSL pair on {coin} disappeared externally; re-arming"
+                )
+                self._tpsl_oids.pop(coin, None)
+                # Fake an "Open" fill payload to reuse the arming logic.
+                await self._maybe_arm_grouped_tpsl(
+                    {"coin": coin, "dir": "Open Long" if position.size > 0 else "Open Short"}
+                )
 
     async def _update_order_statuses(self) -> None:
         """Update status of pending orders"""

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -59,11 +59,20 @@ class TradingEngine:
         # correlate userFills back to the strategy. Periodically swept so
         # never-filled cancelled orders don't leak.
         self._signals_by_oid: Dict[str, Tuple[TradingSignal, float]] = {}
-        # asset -> set of trigger oids registered for that asset's position.
-        # Used to (a) cancel-and-rearm on partial-fill, and (b) detect
-        # external cancellation so we can re-arm.
-        self._tpsl_oids: Dict[str, List[str]] = {}
+        # asset -> {"oids": [...], "dex": str}. Tracks the trigger pair we
+        # registered and the dex it lives on. Used to (a) cancel-and-rearm on
+        # partial-fill, and (b) detect external cancellation so we can re-arm.
+        # Storing the dex avoids paying the cost of an all-dexes scan during
+        # orphan recovery (209+ HIP-3 dexes on testnet).
+        self._tpsl_oids: Dict[str, Dict[str, Any]] = {}
+        # asset -> wallclock of the most recent processed fill on that coin.
+        # Recovery skips coins with a fill in the last RECOVERY_FILL_DEBOUNCE_S
+        # seconds to avoid racing the userFills Close callback when a
+        # trigger fires (open_orders drops the trigger before the WS
+        # delivers the Close fill that clears _tpsl_oids).
+        self._last_fill_ts: Dict[str, float] = {}
         self._signals_oid_ttl_sec = 24 * 3600
+        self.RECOVERY_FILL_DEBOUNCE_S = 10
         self.executed_trades = 0
         self.total_pnl = 0.0
 
@@ -450,11 +459,14 @@ class TradingEngine:
                         f"sz={sz} @ ${px} oid={oid}"
                     )
 
+                coin = fill.get("coin")
+                if coin:
+                    self._last_fill_ts[coin] = time.time()
                 direction = fill.get("dir") or ""
                 if "Open" in direction:
                     await self._maybe_arm_grouped_tpsl(fill)
                 elif "Close" in direction:
-                    self._tpsl_oids.pop(fill.get("coin"), None)
+                    self._tpsl_oids.pop(coin, None)
             except Exception as e:
                 self.logger.error(
                     f"❌ Error handling fill {fill}: {e}"
@@ -509,11 +521,15 @@ class TradingEngine:
 
         # Cancel any prior trigger pair so size and prices reflect the new
         # entry / position size after this partial.
-        for prior_oid in self._tpsl_oids.pop(coin, []):
-            try:
-                await self.exchange.cancel_order(prior_oid)
-            except Exception as e:
-                self.logger.debug(f"prior TPSL cancel skipped ({prior_oid}): {e}")
+        prior = self._tpsl_oids.pop(coin, None)
+        if prior:
+            for prior_oid in prior.get("oids", []):
+                try:
+                    await self.exchange.cancel_order(
+                        prior_oid, dex=prior.get("dex")
+                    )
+                except Exception as e:
+                    self.logger.debug(f"prior TPSL cancel skipped ({prior_oid}): {e}")
 
         tp_price, sl_price = self._tpsl_prices(
             position.entry_price, position.size > 0, tp_pct, sl_pct
@@ -526,11 +542,14 @@ class TradingEngine:
             # Re-read open orders to capture the freshly placed trigger oids
             # so we can cancel-and-rearm or detect external cancellation.
             open_orders = await self.exchange.get_open_orders(dex=position.dex)
-            self._tpsl_oids[coin] = [
-                o.exchange_order_id
-                for o in open_orders
-                if o.asset == coin and o.exchange_order_id
-            ]
+            self._tpsl_oids[coin] = {
+                "oids": [
+                    o.exchange_order_id
+                    for o in open_orders
+                    if o.asset == coin and o.exchange_order_id
+                ],
+                "dex": position.dex,
+            }
             self.logger.info(
                 f"🎯 Armed grouped TP/SL on {coin}: "
                 f"tp={tp_price} sl={sl_price} sz={position.size}"
@@ -580,37 +599,57 @@ class TradingEngine:
     async def _recover_orphaned_tpsl(self) -> None:
         """Re-arm grouped TPSL when the registered trigger orders are gone.
 
-        If the user cancels the trigger pair via the UI while the position is
-        still open, our `_tpsl_oids` map keeps stale ids that no longer exist
-        on the exchange. Detect that and re-arm so the position isn't silently
-        unprotected.
+        If a user cancels the trigger pair via the UI while the position is
+        open, `_tpsl_oids` keeps stale ids; this loop tick re-arms.
+
+        Two safeguards:
+        - Debounce by recent-fill window: don't recover for a coin that had a
+          fill within RECOVERY_FILL_DEBOUNCE_S seconds. This avoids racing the
+          userFills callback that clears `_tpsl_oids` after a legitimate
+          trigger fire (open_orders drops the trigger before the WS delivers
+          the Close fill).
+        - Aggregate across HIP-3 dexes via `all_dexes=True`. Without it, a
+          position on a builder-deployed dex would always look orphaned and
+          re-arm on every tick.
         """
         risk_cfg = self.config.get("risk_management", {})
         if risk_cfg.get("tpsl_mode", "polling") != "grouped":
             return
         if not self._tpsl_oids:
             return
-        try:
-            positions = await self.exchange.get_positions()
-            open_orders = await self.exchange.get_open_orders()
-        except Exception as e:
-            self.logger.debug(f"orphan-recovery skipped: {e}")
-            return
 
-        live_oids = {o.exchange_order_id for o in open_orders if o.exchange_order_id}
-        for coin, oids in list(self._tpsl_oids.items()):
+        now = time.time()
+        # Iterate per-coin and only query the dex we know that coin lives on
+        # (recorded at arming time). Avoids fanning out across 200+ dexes.
+        for coin, entry in list(self._tpsl_oids.items()):
+            last_fill = self._last_fill_ts.get(coin, 0)
+            if now - last_fill < self.RECOVERY_FILL_DEBOUNCE_S:
+                continue
+            dex = entry.get("dex")
+            try:
+                positions = await self.exchange.get_positions(dex=dex)
+                open_orders = await self.exchange.get_open_orders(dex=dex)
+            except Exception as e:
+                self.logger.debug(f"orphan-recovery skipped on {coin}: {e}")
+                continue
             position = next((p for p in positions if p.asset == coin), None)
             if position is None or position.size == 0:
                 self._tpsl_oids.pop(coin, None)
                 continue
-            if not any(o in live_oids for o in oids):
+            live_oids = {
+                o.exchange_order_id for o in open_orders if o.exchange_order_id
+            }
+            if not any(o in live_oids for o in entry.get("oids", [])):
                 self.logger.warning(
                     f"⚠️ TPSL pair on {coin} disappeared externally; re-arming"
                 )
                 self._tpsl_oids.pop(coin, None)
                 # Fake an "Open" fill payload to reuse the arming logic.
                 await self._maybe_arm_grouped_tpsl(
-                    {"coin": coin, "dir": "Open Long" if position.size > 0 else "Open Short"}
+                    {
+                        "coin": coin,
+                        "dir": "Open Long" if position.size > 0 else "Open Short",
+                    }
                 )
 
     async def _update_order_statuses(self) -> None:

--- a/src/core/enhanced_config.py
+++ b/src/core/enhanced_config.py
@@ -189,7 +189,17 @@ class RebalanceConfig:
 
 @dataclass
 class RiskManagementConfig:
-    """Risk management settings - ALL ASSUMPTIONS VISIBLE"""
+    """Risk management settings - ALL ASSUMPTIONS VISIBLE.
+
+    `tpsl_mode` controls how stop-loss / take-profit are enforced:
+      "polling" - legacy: engine polls unrealized_pnl on every price tick
+                  and emits a CLOSE signal when thresholds are crossed.
+                  Races the matching engine; can fire after a sharp move.
+      "grouped" - SDK 0.21+ positionTpsl: at fill time the adapter places
+                  a paired TP/SL trigger pair sized to fully close the
+                  position. The matching engine fires whichever leg hits
+                  first; no polling, no race.
+    """
 
     max_drawdown_pct: float = 15.0  # Stop if % drawdown
     max_position_size_pct: float = 30.0  # Never hold more than % in asset
@@ -197,6 +207,7 @@ class RiskManagementConfig:
     stop_loss_pct: float = 5.0  # Stop loss percentage
     take_profit_enabled: bool = False  # Enable take profit
     take_profit_pct: float = 20.0  # Take profit percentage
+    tpsl_mode: str = "polling"  # "polling" or "grouped"
     rebalance: RebalanceConfig = field(default_factory=RebalanceConfig)
 
     def validate(self) -> None:
@@ -209,6 +220,10 @@ class RiskManagementConfig:
             raise ValueError("stop_loss_pct must be between 1.0 and 20.0")
         if self.take_profit_enabled and not 5.0 <= self.take_profit_pct <= 100.0:
             raise ValueError("take_profit_pct must be between 5.0 and 100.0")
+        if self.tpsl_mode not in ("polling", "grouped"):
+            raise ValueError(
+                f"tpsl_mode must be 'polling' or 'grouped', got {self.tpsl_mode!r}"
+            )
         self.rebalance.validate()
 
 

--- a/src/core/risk_manager.py
+++ b/src/core/risk_manager.py
@@ -302,17 +302,21 @@ class RiskManager:
         """Initialize risk rules from configuration"""
 
         risk_config = self.config.get("risk_management", {})
+        # In "grouped" mode, paired TP/SL trigger orders are placed at fill
+        # time (engine.py); the polling rules become redundant and would race.
+        tpsl_mode = risk_config.get("tpsl_mode", "polling")
+        polling_tpsl = tpsl_mode == "polling"
 
-        # Stop loss rule
-        if risk_config.get("stop_loss_enabled", False):
+        # Stop loss rule (polling-only)
+        if polling_tpsl and risk_config.get("stop_loss_enabled", False):
             self.rules.append(
                 StopLossRule(
                     {"enabled": True, "loss_pct": risk_config.get("stop_loss_pct", 5.0)}
                 )
             )
 
-        # Take profit rule
-        if risk_config.get("take_profit_enabled", False):
+        # Take profit rule (polling-only)
+        if polling_tpsl and risk_config.get("take_profit_enabled", False):
             self.rules.append(
                 TakeProfitRule(
                     {

--- a/src/exchanges/hyperliquid/adapter.py
+++ b/src/exchanges/hyperliquid/adapter.py
@@ -354,6 +354,76 @@ class HyperliquidAdapter(ExchangeAdapter):
 
         return "na"
 
+    async def register_position_tpsl(
+        self,
+        asset: str,
+        position_size: float,
+        tp_price: Optional[float] = None,
+        sl_price: Optional[float] = None,
+        dex: Optional[str] = None,
+    ) -> bool:
+        """Register paired TP/SL trigger orders against a live position.
+
+        Uses SDK 0.21+ `bulk_orders(grouping="positionTpsl")` so the matching
+        engine fires either order without a polling race. `position_size` is
+        signed (long > 0, short < 0); the trigger orders are sized to fully
+        close that position. Pass `tp_price` / `sl_price` in absolute terms;
+        pass `None` to skip a leg. Returns True on placement success.
+        """
+        if not self.is_connected:
+            raise RuntimeError("Not connected to exchange")
+        if position_size == 0:
+            raise RuntimeError("position_size must be non-zero")
+        if tp_price is None and sl_price is None:
+            raise RuntimeError("at least one of tp_price/sl_price must be set")
+
+        from hyperliquid.utils.signing import OrderType as HLOrderType
+
+        is_long = position_size > 0
+        size = abs(position_size)
+        rounded_sz = self._round_size(asset, size, dex=dex)
+
+        requests = []
+        # TP and SL trigger orders are placed on the *opposite* side of the
+        # position so they reduce it. Use isMarket=True for guaranteed exit.
+        if tp_price is not None:
+            tp_px = self._round_price(asset, tp_price, dex=dex)
+            requests.append({
+                "coin": asset,
+                "is_buy": not is_long,
+                "sz": rounded_sz,
+                "limit_px": tp_px,
+                "order_type": HLOrderType({
+                    "trigger": {
+                        "triggerPx": tp_px,
+                        "isMarket": True,
+                        "tpsl": "tp",
+                    }
+                }),
+                "reduce_only": True,
+            })
+        if sl_price is not None:
+            sl_px = self._round_price(asset, sl_price, dex=dex)
+            requests.append({
+                "coin": asset,
+                "is_buy": not is_long,
+                "sz": rounded_sz,
+                "limit_px": sl_px,
+                "order_type": HLOrderType({
+                    "trigger": {
+                        "triggerPx": sl_px,
+                        "isMarket": True,
+                        "tpsl": "sl",
+                    }
+                }),
+                "reduce_only": True,
+            })
+
+        result = self.exchange.bulk_orders(requests, grouping="positionTpsl")
+        if not (result and result.get("status") == "ok"):
+            raise RuntimeError(f"register_position_tpsl failed: {result}")
+        return True
+
     async def disconnect(self) -> None:
         """Disconnect from Hyperliquid"""
         self.is_connected = False

--- a/src/exchanges/hyperliquid/adapter.py
+++ b/src/exchanges/hyperliquid/adapter.py
@@ -354,6 +354,8 @@ class HyperliquidAdapter(ExchangeAdapter):
 
         return "na"
 
+    TPSL_LIMIT_SLIPPAGE = 0.05  # 5%, mirrors market_close default.
+
     async def register_position_tpsl(
         self,
         asset: str,
@@ -361,6 +363,7 @@ class HyperliquidAdapter(ExchangeAdapter):
         tp_price: Optional[float] = None,
         sl_price: Optional[float] = None,
         dex: Optional[str] = None,
+        slippage: float = TPSL_LIMIT_SLIPPAGE,
     ) -> bool:
         """Register paired TP/SL trigger orders against a live position.
 
@@ -368,7 +371,15 @@ class HyperliquidAdapter(ExchangeAdapter):
         engine fires either order without a polling race. `position_size` is
         signed (long > 0, short < 0); the trigger orders are sized to fully
         close that position. Pass `tp_price` / `sl_price` in absolute terms;
-        pass `None` to skip a leg. Returns True on placement success.
+        pass `None` to skip a leg.
+
+        `slippage` biases the order's `limit_px` away from `triggerPx` by that
+        fraction so a single-tick gap past the trigger doesn't leave the
+        market order resting. The reducing side determines direction:
+        sells (long-TP, long-SL) get a *lower* cap; buys (short-TP, short-SL)
+        get a *higher* cap. Default 5% mirrors `market_close`.
+
+        Returns True on placement success.
         """
         if not self.is_connected:
             raise RuntimeError("Not connected to exchange")
@@ -377,52 +388,61 @@ class HyperliquidAdapter(ExchangeAdapter):
         if tp_price is None and sl_price is None:
             raise RuntimeError("at least one of tp_price/sl_price must be set")
 
-        from hyperliquid.utils.signing import OrderType as HLOrderType
-
         is_long = position_size > 0
         size = abs(position_size)
         rounded_sz = self._round_size(asset, size, dex=dex)
 
+        # Reducing side is the opposite of position direction.
+        reducing_is_buy = not is_long
+
         requests = []
-        # TP and SL trigger orders are placed on the *opposite* side of the
-        # position so they reduce it. Use isMarket=True for guaranteed exit.
         if tp_price is not None:
-            tp_px = self._round_price(asset, tp_price, dex=dex)
-            requests.append({
-                "coin": asset,
-                "is_buy": not is_long,
-                "sz": rounded_sz,
-                "limit_px": tp_px,
-                "order_type": HLOrderType({
-                    "trigger": {
-                        "triggerPx": tp_px,
-                        "isMarket": True,
-                        "tpsl": "tp",
-                    }
-                }),
-                "reduce_only": True,
-            })
+            requests.append(
+                self._build_trigger_request(
+                    asset, reducing_is_buy, rounded_sz, tp_price, "tp", slippage, dex
+                )
+            )
         if sl_price is not None:
-            sl_px = self._round_price(asset, sl_price, dex=dex)
-            requests.append({
-                "coin": asset,
-                "is_buy": not is_long,
-                "sz": rounded_sz,
-                "limit_px": sl_px,
-                "order_type": HLOrderType({
-                    "trigger": {
-                        "triggerPx": sl_px,
-                        "isMarket": True,
-                        "tpsl": "sl",
-                    }
-                }),
-                "reduce_only": True,
-            })
+            requests.append(
+                self._build_trigger_request(
+                    asset, reducing_is_buy, rounded_sz, sl_price, "sl", slippage, dex
+                )
+            )
 
         result = self.exchange.bulk_orders(requests, grouping="positionTpsl")
         if not (result and result.get("status") == "ok"):
             raise RuntimeError(f"register_position_tpsl failed: {result}")
         return True
+
+    def _build_trigger_request(
+        self,
+        asset: str,
+        is_buy: bool,
+        sz: float,
+        trigger_price: float,
+        tpsl: str,
+        slippage: float,
+        dex: Optional[str],
+    ) -> Dict[str, Any]:
+        """Build a single reduce-only trigger order request for bulk_orders."""
+        from hyperliquid.utils.signing import OrderType as HLOrderType
+
+        trigger_px = self._round_price(asset, trigger_price, dex=dex)
+        # The limit cap is offset away from the trigger so the IOC market can
+        # fill across a tick of slippage. A reducing buy needs a higher cap;
+        # a reducing sell needs a lower cap.
+        bias = (1 + slippage) if is_buy else (1 - slippage)
+        limit_px = self._round_price(asset, trigger_price * bias, dex=dex)
+        return {
+            "coin": asset,
+            "is_buy": is_buy,
+            "sz": sz,
+            "limit_px": limit_px,
+            "order_type": HLOrderType(
+                {"trigger": {"triggerPx": trigger_px, "isMarket": True, "tpsl": tpsl}}
+            ),
+            "reduce_only": True,
+        }
 
     async def disconnect(self) -> None:
         """Disconnect from Hyperliquid"""

--- a/src/strategies/grid/basic_grid.py
+++ b/src/strategies/grid/basic_grid.py
@@ -55,6 +55,10 @@ class GridConfig:
     # Rebalancing
     rebalance_threshold_pct: float = 15.0  # Rebalance if price moves 15% outside range
 
+    # HIP-3: optional builder-deployed perp dex (None = main perp).
+    # Auto-inferred from "<dex>:<symbol>" prefix when unset.
+    dex: Optional[str] = None
+
 
 class BasicGridStrategy(TradingStrategy):
     """
@@ -72,14 +76,22 @@ class BasicGridStrategy(TradingStrategy):
         super().__init__("basic_grid", config)
 
         # Extract grid config
+        symbol = config.get("symbol", "BTC")
+        # Auto-infer dex from HIP-3 namespaced symbol if not given explicitly.
+        inferred_dex = (
+            symbol.split(":", 1)[0]
+            if ":" in symbol and not symbol.startswith("@")
+            else None
+        )
         self.grid_config = GridConfig(
-            symbol=config.get("symbol", "BTC"),
+            symbol=symbol,
             levels=config.get("levels", 10),
             range_pct=config.get("range_pct", 10.0),
             total_allocation=config.get("total_allocation", 1000.0),
             min_price=config.get("min_price"),
             max_price=config.get("max_price"),
             rebalance_threshold_pct=config.get("rebalance_threshold_pct", 15.0),
+            dex=config.get("dex", inferred_dex),
         )
 
         # Grid state
@@ -148,6 +160,7 @@ class BasicGridStrategy(TradingStrategy):
                             "level_index": level.level_index,
                             "grid_type": "initial",
                         },
+                        dex=self.grid_config.dex,
                     )
                 )
             elif not level.is_buy_level and level.price > current_price:
@@ -163,6 +176,7 @@ class BasicGridStrategy(TradingStrategy):
                             "level_index": level.level_index,
                             "grid_type": "initial",
                         },
+                        dex=self.grid_config.dex,
                     )
                 )
 
@@ -225,6 +239,7 @@ class BasicGridStrategy(TradingStrategy):
                 size=0,  # Close all
                 reason="Rebalancing grid",
                 metadata={"action": "cancel_all"},
+                dex=self.grid_config.dex,
             )
         ]
 


### PR DESCRIPTION
Replaces the engine's synthetic immediate-fill with a real WebSocket userFills subscription, and exposes an opt-in grouped TPSL mode that arms paired TP/SL trigger orders at fill time via SDK 0.21+ \`bulk_orders(grouping="positionTpsl")\`.

## What changes

### Engine (\`src/core/engine.py\`)
- Subscribes to \`userFills\` on \`start()\`; skips the \`isSnapshot=True\` frame so historical fills don't replay.
- \`on_trade_executed\` now fires on actual matching-engine fill, not on \`place_order\` return. Strategies that compound on fills no longer see phantom executions.
- \`{oid -> signal}\` map correlates fill events back to callers; oid normalized to str.
- \`Order.dex\` threaded from \`TradingSignal\` so HIP-3 routing is preserved.

### Adapter (\`src/exchanges/hyperliquid/adapter.py\`)
- \`register_position_tpsl(asset, sz, tp_price, sl_price, dex)\` posts a paired TP/SL trigger pair via \`bulk_orders\` with \`grouping="positionTpsl"\`. Reduce-only market triggers, sized to close the full position.

### Risk manager (\`src/core/risk_manager.py\` + \`enhanced_config.py\`)
- \`tpsl_mode = "polling"\` (default) | \`"grouped"\`.
- In grouped mode the polling \`StopLossRule\` / \`TakeProfitRule\` are omitted so they don't race the trigger pair. Drawdown / position-size rules stay active in both modes.

### Strategy (\`src/strategies/grid/basic_grid.py\`)
- \`GridConfig\` gains optional \`dex\`; auto-inferred from HIP-3 namespaced symbols (\`felix:CRCL\` -> dex=\`felix\`). All \`TradingSignal\`s carry the resolved dex.

### YAML (\`bots/btc_conservative.yaml\`)
- Documents \`tpsl_mode\` with both options.

## Verified live on testnet
Master 0xD876…C56e, agent 0x8b97…728A:
- userFills subscription: snapshot frame (\`isSnapshot=True\`, 30 historical fills) is skipped; live updates flow.
- Engine path: synthesized BUY signal -> oid \`52178839905\` -> live fill -> \`on_trade_executed\` triggered -> grouped TPSL pair (\`TP $80320\`, \`SL $72670\`, both reduce-only sells of 0.0002 BTC) registered automatically. Cancellable, position closes cleanly.
- Polling default rule list: \`[stop_loss, take_profit, max_drawdown, max_position_size]\` (unchanged).
- Grouped rule list: \`[max_drawdown, max_position_size]\`.
- Invalid \`tpsl_mode\` rejected at validate time.
- \`basic_grid\` dex propagation verified for explicit / auto-inferred / plain symbol paths.

## Out of scope (deferred)
- Full risk_manager refactor (rewriting the polling-rule abstraction itself); this PR exposes the trigger-pair mechanism.
- Threading \`dex\` through every remaining learning example.
- Mainnet validation (per direction, postponed).

## Test plan
- [x] \`uv run src/run_bot.py --validate bots/btc_conservative.yaml\` (with \`tpsl_mode: polling\` then \`tpsl_mode: grouped\`)
- [ ] \`uv run src/run_bot.py bots/btc_conservative.yaml\` against testnet, observe \`💱 Filled\` log on real fill (not on placement)
- [x] With \`tpsl_mode: grouped\` + a stop_loss/take_profit set, observe \`🎯 Armed grouped TP/SL\` and the pair appearing in \`info.open_orders\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)