### PR TITLE
Route info calls between Chainstack and public; redact secrets in logs

### DIFF
--- a/src/core/endpoint_router.py
+++ b/src/core/endpoint_router.py
@@ -6,14 +6,53 @@ Supports multiple providers (public, Chainstack) with method-specific routing.
 """
 
 import os
+import re
 import asyncio
 import time
 import logging
-from typing import Dict, List, Optional, Tuple, Callable, Any
+from typing import Dict, List, Optional, Set, Tuple, Callable, Any
 from dataclasses import dataclass
 from enum import Enum
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
+
+
+_TOKEN_SEG = re.compile(r"^[A-Za-z0-9_-]{16,}$")
+
+
+def redact_address(addr: Optional[str]) -> str:
+    """Shorten a hex address to ``0xXXXX…YYYY`` for safe logging."""
+    if not addr:
+        return ""
+    s = str(addr)
+    if s.startswith("0x") and len(s) > 12:
+        return f"{s[:6]}…{s[-4:]}"
+    if len(s) > 10:
+        return f"{s[:4]}…{s[-4:]}"
+    return s
+
+
+def redact_url(url: str) -> str:
+    """Replace API-key-looking path segments with ``***`` for safe logging.
+
+    Long alphanumeric segments (16+ chars) are treated as secrets;
+    short route names like ``info`` / ``exchange`` / ``evm`` are kept.
+    """
+    if not url:
+        return url
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+    if not parts.path:
+        return url
+    redacted = [
+        "***" if _TOKEN_SEG.match(seg) else seg for seg in parts.path.split("/")
+    ]
+    return urlunsplit(
+        (parts.scheme, parts.netloc, "/".join(redacted), parts.query, parts.fragment)
+    )
 
 
 class EndpointType(Enum):
@@ -120,6 +159,24 @@ class HyperliquidEndpointRouter:
         "subscribe_user_events": [EndpointType.WEBSOCKET],
     }
 
+    # Methods known to be unsupported on a given provider for a given network.
+    # Probed against Chainstack testnet 2026-05-11: this subset of /info methods
+    # returns HTTP 422 upstream. Public endpoint handles them.
+    PROVIDER_INCOMPATIBLE_METHODS: Dict[Tuple["Provider", bool], Set[str]] = {
+        (Provider.CHAINSTACK, True): {
+            "all_mids",
+            "user_state",
+            "l2_book",
+            "meta_and_asset_ctxs",
+            "spot_meta_and_asset_ctxs",
+            "predicted_fundings",
+            "all_dexs_asset_ctxs",
+            "candles",
+            "candles_snapshot",
+        },
+        (Provider.CHAINSTACK, False): set(),
+    }
+
     # Provider priority for each endpoint type (first = preferred)
     PROVIDER_PRIORITIES = {
         EndpointType.INFO: [
@@ -187,7 +244,7 @@ class HyperliquidEndpointRouter:
 
                 self.endpoints.append(config)
                 self.logger.debug(
-                    f"Loaded {provider.value} {endpoint_type.value} endpoint: {url[:50]}..."
+                    f"Loaded {provider.value} {endpoint_type.value} endpoint: {redact_url(url)}"
                 )
 
         if not self.endpoints:
@@ -272,7 +329,7 @@ class HyperliquidEndpointRouter:
 
         # For each endpoint type, try to find the best provider
         for endpoint_type in compatible_types:
-            endpoint = self._get_best_endpoint(endpoint_type)
+            endpoint = self._get_best_endpoint(endpoint_type, method_name)
             if endpoint:
                 self.logger.debug(
                     f"Routing {method_name} to {endpoint.provider.value} {endpoint.endpoint_type.value}"
@@ -282,22 +339,73 @@ class HyperliquidEndpointRouter:
         self.logger.error(f"No healthy endpoints available for method: {method_name}")
         return None
 
+    def get_info_routing(
+        self,
+    ) -> Optional[Tuple[EndpointConfig, Optional[EndpointConfig], Set[str]]]:
+        """Resolve INFO routing as ``(primary, fallback, primary_unsupported)``.
+
+        ``primary`` is the preferred INFO endpoint (typically Chainstack when
+        configured); ``fallback`` is a different-provider endpoint to use for
+        methods listed in ``primary_unsupported``. Returns ``None`` if no INFO
+        endpoint is configured at all.
+        """
+        info_endpoints = [
+            ep
+            for ep in self.endpoints
+            if ep.endpoint_type == EndpointType.INFO and ep.is_healthy
+        ]
+        if not info_endpoints:
+            return None
+
+        priorities = self.PROVIDER_PRIORITIES.get(EndpointType.INFO, [])
+
+        def sort_key(ep: EndpointConfig) -> Tuple[int, int]:
+            provider_idx = (
+                priorities.index(ep.provider) if ep.provider in priorities else 999
+            )
+            return (provider_idx, ep.priority)
+
+        info_endpoints.sort(key=sort_key)
+        primary = info_endpoints[0]
+        fallback = next(
+            (ep for ep in info_endpoints[1:] if ep.provider != primary.provider),
+            None,
+        )
+        unsupported = self.PROVIDER_INCOMPATIBLE_METHODS.get(
+            (primary.provider, primary.testnet), set()
+        )
+        return primary, fallback, unsupported
+
     def _get_best_endpoint(
-        self, endpoint_type: EndpointType
+        self,
+        endpoint_type: EndpointType,
+        method_name: Optional[str] = None,
     ) -> Optional[EndpointConfig]:
         """Get the best available endpoint for a specific type"""
 
-        # Filter endpoints by type and health
+        def supports_method(ep: EndpointConfig) -> bool:
+            if method_name is None:
+                return True
+            blocked = self.PROVIDER_INCOMPATIBLE_METHODS.get(
+                (ep.provider, ep.testnet), set()
+            )
+            return method_name not in blocked
+
+        # Filter endpoints by type, health, and per-method compatibility
         candidates = [
             ep
             for ep in self.endpoints
-            if ep.endpoint_type == endpoint_type and ep.is_healthy
+            if ep.endpoint_type == endpoint_type
+            and ep.is_healthy
+            and supports_method(ep)
         ]
 
         if not candidates:
             # If no healthy endpoints, try unhealthy ones as last resort
             candidates = [
-                ep for ep in self.endpoints if ep.endpoint_type == endpoint_type
+                ep
+                for ep in self.endpoints
+                if ep.endpoint_type == endpoint_type and supports_method(ep)
             ]
             if candidates:
                 self.logger.warning(

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -82,6 +82,9 @@ class TradingEngine:
             level=getattr(logging, config.get("log_level", "INFO")),
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
+        # httpx logs every HTTP request at INFO and includes the full URL,
+        # which would leak the Chainstack token path. Silence below WARNING.
+        logging.getLogger("httpx").setLevel(logging.WARNING)
 
     async def initialize(self) -> bool:
         """Initialize all components"""

--- a/src/exchanges/hyperliquid/adapter.py
+++ b/src/exchanges/hyperliquid/adapter.py
@@ -17,7 +17,7 @@ from interfaces.exchange import (
     Balance,
     MarketInfo,
 )
-from core.endpoint_router import get_endpoint_router
+from core.endpoint_router import get_endpoint_router, redact_address, redact_url
 
 
 class HyperliquidAdapter(ExchangeAdapter):
@@ -96,32 +96,40 @@ class HyperliquidAdapter(ExchangeAdapter):
             from hyperliquid.exchange import Exchange
             from eth_account import Account
 
-            # Get the info endpoint from router
-            info_url = self.endpoint_router.get_endpoint_for_method("user_state")
-            if not info_url:
+            from .routing_info import RoutingInfoClient
+
+            info_routing = self.endpoint_router.get_info_routing()
+            if not info_routing:
                 raise RuntimeError("No healthy info endpoint available")
+            primary_info_ep, fallback_info_ep, primary_unsupported = info_routing
 
             # Get the exchange endpoint from router
             exchange_url = self.endpoint_router.get_endpoint_for_method("cancel_order")
             if not exchange_url:
                 raise RuntimeError("No healthy exchange endpoint available")
 
-            # Remove /info and /exchange suffixes (SDK adds them automatically)
-            info_base_url = (
-                info_url.replace("/info", "")
-                if info_url.endswith("/info")
-                else info_url
+            def strip_suffix(url: str, suffix: str) -> str:
+                return url[: -len(suffix)] if url.endswith(suffix) else url
+
+            primary_info_base = strip_suffix(primary_info_ep.url, "/info")
+            fallback_info_base = (
+                strip_suffix(fallback_info_ep.url, "/info")
+                if fallback_info_ep
+                else None
             )
-            exchange_base_url = (
-                exchange_url.replace("/exchange", "")
-                if exchange_url.endswith("/exchange")
-                else exchange_url
-            )
+            exchange_base_url = strip_suffix(exchange_url, "/exchange")
 
             wallet = Account.from_key(self.private_key)
             self.account_address = self.account_address or wallet.address
 
-            self.info = Info(info_base_url, skip_ws=True)
+            primary_info = Info(primary_info_base, skip_ws=True)
+            if fallback_info_base and primary_unsupported:
+                fallback_info = Info(fallback_info_base, skip_ws=True)
+                self.info = RoutingInfoClient(
+                    primary_info, fallback_info, primary_unsupported
+                )
+            else:
+                self.info = primary_info
             self.exchange = Exchange(
                 wallet, exchange_base_url, account_address=self.account_address
             )
@@ -140,10 +148,24 @@ class HyperliquidAdapter(ExchangeAdapter):
             print(
                 f"✅ Connected to Hyperliquid ({'testnet' if self.testnet else 'mainnet'})"
             )
-            print(f"📡 Info endpoint: {info_url}")
-            print(f"💱 Exchange endpoint: {exchange_url}")
-            print(f"🔑 Signer (agent): {wallet.address}")
-            print(f"🏦 Account (master): {self.account_address}")
+            if fallback_info_ep and primary_unsupported:
+                print(
+                    f"📡 Info endpoint: {redact_url(primary_info_ep.url)} "
+                    f"({primary_info_ep.provider.value})"
+                )
+                print(
+                    f"   ↳ fallback for {len(primary_unsupported)} methods: "
+                    f"{redact_url(fallback_info_ep.url)} "
+                    f"({fallback_info_ep.provider.value})"
+                )
+            else:
+                print(
+                    f"📡 Info endpoint: {redact_url(primary_info_ep.url)} "
+                    f"({primary_info_ep.provider.value})"
+                )
+            print(f"💱 Exchange endpoint: {redact_url(exchange_url)}")
+            print(f"🔑 Signer (agent): {redact_address(wallet.address)}")
+            print(f"🏦 Account (master): {redact_address(self.account_address)}")
             return True
 
         except Exception as e:

--- a/src/exchanges/hyperliquid/market_data.py
+++ b/src/exchanges/hyperliquid/market_data.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional, Callable, Any
 import time
 
 from interfaces.strategy import MarketData
-from core.endpoint_router import get_endpoint_router
+from core.endpoint_router import get_endpoint_router, redact_address, redact_url
 
 
 class HyperliquidMarketData:
@@ -84,7 +84,7 @@ class HyperliquidMarketData:
             print(
                 f"✅ Connected to Hyperliquid WebSocket ({'testnet' if self.testnet else 'mainnet'})"
             )
-            print(f"📡 Using WebSocket: {ws_url}")
+            print(f"📡 Using WebSocket: {redact_url(ws_url)}")
             return True
 
         except Exception as e:
@@ -194,7 +194,11 @@ class HyperliquidMarketData:
         await self.ws.send(
             json.dumps({"method": "subscribe", "subscription": subscription})
         )
-        print(f"📡 Subscribed to channel: {subscription}")
+        display_sub = {
+            k: (redact_address(v) if k == "user" and isinstance(v, str) else v)
+            for k, v in subscription.items()
+        }
+        print(f"📡 Subscribed to channel: {display_sub}")
 
     def get_latest_price(self, asset: str) -> Optional[float]:
         """Get latest cached price for an asset"""
@@ -336,7 +340,7 @@ class HyperliquidMarketData:
             print(
                 f"✅ Connected to Hyperliquid WebSocket ({'testnet' if self.testnet else 'mainnet'})"
             )
-            print(f"📡 Using WebSocket: {ws_url}")
+            print(f"📡 Using WebSocket: {redact_url(ws_url)}")
             return True
 
         except Exception as e:

--- a/src/exchanges/hyperliquid/routing_info.py
+++ b/src/exchanges/hyperliquid/routing_info.py
@@ -1,0 +1,26 @@
+"""Routing wrapper around two Hyperliquid SDK ``Info`` clients.
+
+Primary provider (e.g. Chainstack) handles every call except the ones it is
+known to reject; those are transparently delegated to the public fallback.
+"""
+
+from typing import Optional, Set
+
+
+class RoutingInfoClient:
+    def __init__(
+        self,
+        primary,
+        fallback,
+        primary_unsupported: Optional[Set[str]] = None,
+    ):
+        self._primary = primary
+        self._fallback = fallback
+        self._unsupported: Set[str] = set(primary_unsupported or ())
+
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        if self._fallback is not None and name in self._unsupported:
+            return getattr(self._fallback, name)
+        return getattr(self._primary, name)

--- a/src/run_bot.py
+++ b/src/run_bot.py
@@ -57,7 +57,11 @@ class GridTradingBot:
 
         try:
             # Load configuration
-            print(f"📁 Loading configuration: {self.config_path}")
+            try:
+                display_path = Path(self.config_path).resolve().relative_to(Path.cwd())
+            except ValueError:
+                display_path = Path(self.config_path).name
+            print(f"📁 Loading configuration: {display_path}")
             self.config = EnhancedBotConfig.from_yaml(Path(self.config_path))
             print(f"✅ Configuration loaded: {self.config.name}")
 


### PR DESCRIPTION
## Summary
- Make Chainstack actually usable for `/info` calls: a probe of the testnet node showed 9 methods (`allMids`, `userState`, `l2Book`, `metaAndAssetCtxs`, `spotMetaAndAssetCtxs`, `predictedFundings`, `allDexsAssetCtxs`, `candles`, `candleSnapshot`) return HTTP 422 upstream, while the rest (`meta`, `spotMeta`, `clearinghouseState`, `openOrders`, `perpDexs`, ...) return 200. The adapter now holds two SDK `Info` clients (Chainstack primary + public fallback) and dispatches each call by name using a static skip-list — supported methods hit Chainstack, the rest transparently hit public.
- Redact secrets in the bot's startup output so screenshots/logs can be shared safely: Chainstack token segments in URLs become `***`, wallet addresses are shortened to `0xXXXX…YYYY`, the config path is printed relative to CWD, and httpx's INFO-level request log (which embedded the full URL on every call) is silenced.
- No `.env` changes are part of this PR (it's gitignored); enabling Chainstack still requires setting `HYPERLIQUID_TESTNET_CHAINSTACK_*_URL`.

## What the boot output looks like now

```
📁 Loading configuration: bots/btc_conservative.yaml
✅ Connected to Hyperliquid (testnet)
📡 Info endpoint: https://hyperliquid-testnet.core.chainstack.com/***/info (chainstack)
   ↳ fallback for 9 methods: https://api.hyperliquid-testnet.xyz/info (public)
💱 Exchange endpoint: https://api.hyperliquid-testnet.xyz/exchange
🔑 Signer (agent): 0x8b97…728A
🏦 Account (master): 0xD876…C56e
```

## Test plan
- [x] `uv run src/run_bot.py --validate` passes
- [x] End-to-end run on testnet with both Chainstack and public INFO configured: grid placed 9 orders successfully (Chainstack served meta/openOrders/clearinghouseState; public served allMids/userState)
- [x] Confirmed redaction: Chainstack token does not appear in any log line; addresses display as `0xXXXX…YYYY`; config path is relative
- [x] Mainnet routing untested — `PROVIDER_INCOMPATIBLE_METHODS[(CHAINSTACK, False)]` is an empty set; if mainnet has any 422s they should be added there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced endpoint routing with provider-specific method compatibility detection
  * Added sensitive data redaction in logging to improve security

* **Improvements**
  * Reduced verbose logging output to prevent exposure of connection details
  * Strengthened adapter connections with fallback endpoint support
  * Improved configuration logging with better path formatting

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chainstacklabs/hyperliquid-trading-bot/pull/13)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->